### PR TITLE
Fix header connection status and adjust layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -43,7 +43,7 @@ body{
 .nav-ico{font-size:16px}
 .auth-actions{display:flex; gap:8px; justify-content:flex-end}
 .login-status{display:flex; align-items:center; gap:4px; color:var(--ok); font-weight:600; text-transform:capitalize}
-.login-status .check{font-size:14px}
+.login-status[hidden]{display:none}
 
 .site-footer{border-top:1px solid var(--border); margin-top:56px; background:#ffffff}
 .site-footer .container{padding:28px 0}
@@ -73,11 +73,11 @@ body{
 .nav-backdrop{position:fixed; inset:0; background:rgba(0,0,0,.25); backdrop-filter:blur(2px); z-index:8; display:none}
 .nav-backdrop.open{display:block}
 
-.hero{padding:48px 0 28px; margin-bottom:16px}
-@media(max-width:900px){.hero{padding:44px 0 24px}}
+.hero{padding:24px 0 28px; margin-bottom:16px}
+@media(max-width:900px){.hero{padding:20px 0 24px}}
 .hero-content{display:grid; grid-template-columns:1.05fr .95fr; align-items:center; gap:24px}
 @media(max-width:900px){.hero-content{grid-template-columns:1fr}}
-.hero h1{font-size:clamp(32px, 5.4vw, 56px); margin:4px 0 10px; letter-spacing:.2px; font-weight:800; background:linear-gradient(90deg,var(--violet), var(--turquoise)); -webkit-background-clip:text; color:transparent; text-shadow:0 2px 4px rgba(0,0,0,.1)}
+.hero h1{font-size:clamp(32px, 5.4vw, 56px); margin:4px 0 10px; letter-spacing:.2px; font-weight:800; color:var(--text)}
 .hero-copy{max-width:620px}
 .hero-badge{background:rgba(255,255,255,.12); border-color:rgba(255,255,255,.22)}
 .lead{color:var(--muted); margin:0 0 18px}
@@ -177,10 +177,10 @@ input[type="file"]{padding:8px}
 .section{padding:32px 0}
 .hero + .section{padding-top:44px}
 .section.alt{background:#f8faff; border-top:none; border-bottom:none}
-.section-title{margin:0 0 8px; font-size:clamp(20px, 3vw, 28px); text-align:center}
+.section-title{margin:0 0 8px; font-size:clamp(24px, 3.4vw, 32px); text-align:center}
 .section-subtitle{margin:0 0 24px; color:var(--muted); text-align:center}
 .page-header{display:grid; gap:6px; justify-items:center; text-align:center; margin:4px 0 18px}
-.page-header h2{margin:0; font-size:clamp(22px, 3.2vw, 30px)}
+.page-header h2{margin:0; font-size:clamp(26px, 3.6vw, 34px)}
 .page-subtitle{margin:0; color:var(--muted)}
 .page-actions{margin-top:6px}
 .features{display:grid; grid-template-columns:repeat(auto-fit, minmax(220px,1fr)); gap:12px}

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
           <a href="#/settings" class="nav-link"><span class="nav-ico">⚙️</span><span>Paramètres</span></a>
         </nav>
         <div class="auth-actions">
-          <span id="login-status" class="login-status" hidden>connecté <span class="check">✔</span></span>
+          <span id="login-status" class="login-status" hidden>connecté</span>
           <button id="btn-login" class="btn btn-secondary">Se connecter</button>
           <button id="btn-logout" class="btn btn-secondary" hidden>Se déconnecter</button>
         </div>


### PR DESCRIPTION
## Summary
- hide connection status when logged out and remove check icon
- reduce masthead/hero spacing and simplify hero heading style
- enlarge section titles for better prominence

## Testing
- `npm test` *(fails: npm: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c016621d488321870260a8e0fce910