### PR TITLE
Improve AI tools layout and chat reset placement

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -364,25 +364,17 @@
     const fChat = document.getElementById('form-ai-chat');
     const sChat = document.getElementById('ai-chat-status');
     const msgsEl = document.getElementById('ai-chat-messages');
-    // Add reset button at top of chat window
-    try {
-      const chatWindow = fChat?.closest('.chat-window');
-      if (chatWindow && !document.getElementById('ai-chat-reset')) {
-        const btnReset = document.createElement('button');
-        btnReset.type = 'button';
-        btnReset.id = 'ai-chat-reset';
-        btnReset.className = 'btn btn-secondary chat-reset';
-        btnReset.textContent = 'Réinitialiser la discussion';
-        chatWindow.prepend(btnReset);
-        btnReset.addEventListener('click', (e) => {
-          e.preventDefault();
-          const key = chatKey(currentChild);
-          try { localStorage.removeItem(key); } catch {}
-          renderChat([]);
-          sChat.textContent = '';
-        });
-      }
-    } catch {}
+    const btnReset = document.getElementById('ai-chat-reset');
+    if (btnReset && !btnReset.dataset.bound) {
+      btnReset.addEventListener('click', (e) => {
+        e.preventDefault();
+        const key = chatKey(currentChild);
+        try { localStorage.removeItem(key); } catch {}
+        renderChat([]);
+        sChat.textContent = '';
+      });
+      btnReset.dataset.bound = '1';
+    }
     if (fChat && !fChat.dataset.bound) fChat.addEventListener('submit', async (e) => {
       e.preventDefault();
       const q = new FormData(fChat).get('q')?.toString().trim();

--- a/assets/style.css
+++ b/assets/style.css
@@ -138,6 +138,8 @@ a.btn, a.btn:visited, a.btn:hover, a.btn:focus{ text-decoration:none !important;
 .stack{display:grid; gap:12px}
 .hstack{display:flex; gap:12px; align-items:center; flex-wrap:wrap}
 .flex-between{display:flex; justify-content:space-between; align-items:center; gap:12px}
+.card-header{display:grid; gap:6px}
+.card-header h3,.card-header p{margin:0}
 
 .form-grid{display:grid; gap:12px}
 label{display:grid; gap:6px; font-size:14px}
@@ -145,6 +147,7 @@ input, select, textarea{width:100%; background:#ffffff; border:1px solid var(--b
 input::placeholder, textarea::placeholder{color:#8aa0bf}
 input:focus, select:focus, textarea:focus{box-shadow:0 0 0 2px rgba(138,182,255,.5); border-color:#b9cffd}
 input[type="file"]{padding:8px}
+input[type="checkbox"]{width:auto}
 .switch{display:flex; align-items:center; gap:10px}
 .muted{color:var(--muted)}
 

--- a/index.html
+++ b/index.html
@@ -358,8 +358,10 @@
           </div>
 
           <div class="card stack">
-            <h3>Générateur d’histoires personnalisées</h3>
-            <p class="muted">Des histoires courtes adaptées à l’âge, au prénom et aux centres d’intérêt de l’enfant.</p>
+            <div class="card-header">
+              <h3>Générateur d’histoires personnalisées</h3>
+              <p class="muted">Des histoires courtes adaptées à l’âge, au prénom et aux centres d’intérêt de l’enfant.</p>
+            </div>
             <form id="form-ai-story" class="form-grid">
               <label>Thème (optionnel)
                 <input type="text" name="theme" placeholder="Ex: animaux, espace, pirates…" />
@@ -384,8 +386,11 @@
           </div>
 
           <div class="card stack">
-            <h3>Chatbot personnalisé</h3>
-            <p class="muted">Un assistant qui tient compte de l’âge, des jalons et du contexte (garde, langues, antécédents) renseignés.</p>
+            <div class="card-header">
+              <h3>Chatbot personnalisé</h3>
+              <p class="muted">Un assistant qui tient compte de l’âge, des jalons et du contexte (garde, langues, antécédents) renseignés.</p>
+            </div>
+            <button id="ai-chat-reset" class="btn btn-secondary chat-reset" type="button">Réinitialiser la discussion</button>
             <div class="chat-window">
               <div id="ai-chat-messages" class="chat-messages"></div>
               <form id="form-ai-chat" class="chat-input" autocomplete="off">


### PR DESCRIPTION
## Summary
- Wrap AI tool titles and subtitles in a shared header for tighter spacing
- Fix checkbox width in story generator so label sits next to checkbox
- Place "Réinitialiser la discussion" button above chat window and wire up listener

## Testing
- `npm test` (fails: Missing script: "test")
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68c026b092f0832193f8001385ce5256