### PR TITLE
Enhance visibility of child data points on dashboard charts

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1525,12 +1525,20 @@
       path.setAttribute('stroke-width','2.5');
       svg.appendChild(path);
       // Points
-      pts.forEach(p=>{
+      pts.forEach((p,i)=>{
         const c = document.createElementNS('http://www.w3.org/2000/svg','circle');
+        const isChild = idx === 0;
+        const isLatest = isChild && i === pts.length - 1;
         c.setAttribute('cx', xScale(p.x));
         c.setAttribute('cy', yScale(p.y));
-        c.setAttribute('r','2.5');
+        c.setAttribute('r', isChild ? (isLatest ? '6' : '4') : '2.5');
         c.setAttribute('fill', s.color || 'cyan');
+        if (isChild) {
+          c.setAttribute('stroke', '#fff');
+          c.setAttribute('stroke-width', '1.5');
+          c.classList.add('child-point');
+          if (isLatest) c.classList.add('child-point-latest');
+        }
         svg.appendChild(c);
       });
     });

--- a/assets/style.css
+++ b/assets/style.css
@@ -184,6 +184,9 @@ input[type="checkbox"]{width:auto}
 .legend-item{display:flex; align-items:center; gap:6px; font-size:12px}
 .legend-dot{width:10px; height:10px; border-radius:50%}
 .chart{display:block; width:100%; height:240px}
+.child-point{stroke:#ffffff; stroke-width:1.5}
+.child-point-latest{animation:breathe 2s ease-in-out infinite; transform-box:fill-box; transform-origin:center}
+@keyframes breathe{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.4);opacity:.5}}
 
 /* Landing sections */
 .section{padding:32px 0}


### PR DESCRIPTION
## Summary
- Highlight child's measurements with larger, white-outlined markers
- Animate the most recent child point with a subtle pulsing effect

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c02eb4360483218f9cd20b113d6456