### PR TITLE
feat: add child selector in settings

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1641,6 +1641,8 @@ try {
 
     const list = $('#children-list');
     list.innerHTML = '';
+    const selector = $('#child-select');
+    if (selector) selector.innerHTML = '';
     let children = [];
     if (useRemote()) {
       try {
@@ -1654,6 +1656,25 @@ try {
     }
     // If another render started, abort appending to avoid duplicates
     if (rid !== renderSettings._rid) return;
+
+    const editBox = document.getElementById('child-edit');
+    let currentEditId = editBox?.getAttribute('data-edit-id') || selector?.value || null;
+    if (!currentEditId && children[0]) currentEditId = children[0].id;
+
+    if (selector) {
+      selector.innerHTML = children
+        .map(c => `<option value="${c.id}" ${c.id===currentEditId?'selected':''}>${escapeHtml(c.first_name||c.firstName||'—')}</option>`)
+        .join('');
+      if (!selector.dataset.bound) {
+        selector.addEventListener('change', () => {
+          const id = selector.value;
+          editBox?.setAttribute('data-edit-id', id);
+          renderSettings();
+        });
+        selector.dataset.bound = '1';
+      }
+    }
+
     children.forEach(c => {
       const firstName = c.first_name || c.firstName;
       const dob = c.dob;
@@ -1718,9 +1739,6 @@ try {
     }
 
     // Child edit form render
-    const editBox = document.getElementById('child-edit');
-    let currentEditId = editBox?.getAttribute('data-edit-id') || null;
-    if (!currentEditId && children[0]) currentEditId = children[0].id;
     let child = null;
     if (useRemote()) {
       const c = (children||[]).find(x=>x.id===currentEditId) || children[0];

--- a/index.html
+++ b/index.html
@@ -456,6 +456,9 @@
 
           <div class="card stack">
             <h3>Gestion multi‑enfants</h3>
+            <label>Sélectionner un enfant
+              <select id="child-select"></select>
+            </label>
             <div id="children-list" class="stack"></div>
             <div id="child-edit" class="stack"></div>
             <a class="btn btn-secondary" href="#/onboarding">Ajouter un profil enfant</a>


### PR DESCRIPTION
## Summary
- add child selector dropdown in settings for choosing which child profile to manage
- wire selector in app logic to update edit form when selection changes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1446005348321b503cdd99a4018f2