### PR TITLE
Ajoute espacement dans le Dashboard

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1164,6 +1164,8 @@ try {
       const updates = getChildUpdates(child.id).slice().reverse(); // latest first
       const hist = document.createElement('div');
       hist.className = 'card stack';
+      // Add spacing from the health profile section
+      hist.style.marginTop = '20px';
       hist.innerHTML = `<h3>Historique des mises à jour</h3>` + (
         updates.length ?
         `<div class="stack">${updates.map(u => {


### PR DESCRIPTION
## Summary
- Ajoute un margin-top au bloc Historique des mises à jour pour séparer visuellement le Profil santé dans le Dashboard.

## Testing
- `npm test` (échoue : Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c14adb3668832197d7d7b02f569701