### PR TITLE
Add env API endpoint

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -165,6 +165,12 @@ const server = createServer(async (req, res) => {
     });
   }
 
+  if (req.method === 'GET' && url.pathname === '/api/env') {
+    const urlEnv = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || '';
+    return send(res, 200, JSON.stringify({ url: urlEnv, anonKey }), { 'Content-Type': 'application/json; charset=utf-8' });
+  }
+
   if (req.method === 'POST' && url.pathname === '/api/ai/advice') {
     try {
       const body = await parseJson(req);


### PR DESCRIPTION
## Summary
- add `/api/env` route to serve Supabase URL and anon key

## Testing
- `curl -i http://localhost:3000/api/env`


------
https://chatgpt.com/codex/tasks/task_e_68c16838d18c8321a92f1ac8c825a3ee