### PR TITLE
Ensure homepage renders without JavaScript

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,4 +1,5 @@
 // Synap'Kids SPA — Front-only prototype with localStorage + Supabase Auth (Google)
+document.documentElement.classList.add('js');
 import { DEV_QUESTIONS } from './questions-dev.js';
 console.log('Loaded DEV_QUESTIONS:', DEV_QUESTIONS);
 (async () => {

--- a/assets/style.css
+++ b/assets/style.css
@@ -325,8 +325,10 @@ input[type="checkbox"]{width:auto}
 .grid-2{display:grid; gap:12px; grid-template-columns:1fr;}
 @media(min-width:900px){.grid-2{grid-template-columns:1.2fr .8fr}}
 
-.route{display:none; padding:24px 0}
-.route.active{display:block}
+.route{padding:24px 0}
+html:not(.js) .route:not([data-route="/"]){display:none}
+html.js .route{display:none}
+html.js .route.active{display:block}
 
 .chip{display:inline-flex; align-items:center; gap:6px; border:1px solid var(--border); background:#ffffff; padding:6px 12px; border-radius:999px; font-size:12px}
 


### PR DESCRIPTION
## Summary
- Avoid hiding routes when JavaScript fails by defaulting to visible home section
- Mark `js` class when app script loads so routing continues to work when supported

## Testing
- `node --check assets/app.js && echo "syntax ok"`
- `timeout 1 node api/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68c187b9ddf08321b7fccc112e4f1935