### PR TITLE
Ensure homepage renders without JavaScript

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -36,6 +36,8 @@ console.log('Loaded DEV_QUESTIONS:', DEV_QUESTIONS);
   const DEBUG_AUTH = (typeof localStorage !== 'undefined' && localStorage.getItem('debug_auth') === '1');
 
   // Load Supabase env and client
+  // Remove "js" marker if any runtime error bubbles up
+  window.addEventListener('error', () => document.documentElement.classList.remove('js'));
   let supabase = null;
   let authSession = null;
   // Reveal observer (initialized later in setupScrollAnimations)
@@ -2432,9 +2434,10 @@ try {
   }
 
   // Init
-  bootstrap();
-  if (!location.hash) location.hash = '#/';
-  setActiveRoute(location.hash);
+    bootstrap();
+    if (!location.hash) location.hash = '#/';
+    setActiveRoute(location.hash);
+    document.documentElement.classList.add('js');
   // Evaluate header fit on load
   evaluateHeaderFit();
   // Footer year (replaces inline script to satisfy CSP)

--- a/assets/style.css
+++ b/assets/style.css
@@ -325,8 +325,10 @@ input[type="checkbox"]{width:auto}
 .grid-2{display:grid; gap:12px; grid-template-columns:1fr;}
 @media(min-width:900px){.grid-2{grid-template-columns:1.2fr .8fr}}
 
-.route{display:none; padding:24px 0}
-.route.active{display:block}
+.route{padding:24px 0}
+html:not(.js) .route:not([data-route="/"]){display:none}
+html.js .route{display:none}
+html.js .route.active{display:block}
 
 .chip{display:inline-flex; align-items:center; gap:6px; border:1px solid var(--border); background:#ffffff; padding:6px 12px; border-radius:999px; font-size:12px}
 


### PR DESCRIPTION
## Summary
- Remove premature `js` class addition so routes stay visible until initialization completes
- Drop the `js` marker if a runtime error occurs to reveal the fallback home section

## Testing
- `node --check assets/app.js && echo "syntax ok"`
- `timeout 1 node api/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68c187b9ddf08321b7fccc112e4f1935