### PR TITLE
Add messaging page with Supabase realtime notifications

### DIFF
--- a/assets/messages.js
+++ b/assets/messages.js
@@ -1,0 +1,176 @@
+document.body.classList.remove('no-js');
+const $ = (sel, root=document) => root.querySelector(sel);
+const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
+
+let supabase, session, user;
+let parents = [];
+let activeParent = null;
+let currentMessages = [];
+let messagesChannel = null;
+let notifChannel = null;
+let notifications = [];
+
+function escapeHTML(str){
+  return str.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+}
+
+async function init(){
+  try {
+    const env = await fetch('/api/env').then(r=>r.json());
+    const { createClient } = await import('https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm');
+    supabase = createClient(env.url, env.anonKey, { auth: { persistSession:true, autoRefreshToken:true } });
+    const { data: { session:s } } = await supabase.auth.getSession();
+    if(!s){ alert('Veuillez vous connecter.'); window.location.href='/'; return; }
+    session = s; user = s.user;
+    await loadParents();
+    await loadNotifications();
+    setupNotifButton();
+    setupSubscriptions();
+  } catch (e){ console.error('Init error', e); }
+}
+
+async function loadParents(){
+  const list = $('#parents-list');
+  list.innerHTML = '<li>Chargement…</li>';
+  const { data, error } = await supabase.from('profiles').select('id,full_name,avatar_url').neq('id', user.id);
+  if(error){ list.innerHTML = '<li>Erreur.</li>'; return; }
+  parents = data || [];
+  list.innerHTML='';
+  parents.forEach(p=>{
+    const li = document.createElement('li');
+    li.className='parent-item';
+    li.dataset.id = p.id;
+    li.innerHTML = `<img src="${p.avatar_url||'/logo.png'}" alt="" class="avatar" width="32" height="32"> <span>${p.full_name||'Parent'}</span>`;
+    li.addEventListener('click', ()=>openConversation(p.id));
+    list.appendChild(li);
+  });
+}
+
+async function openConversation(otherId){
+  activeParent = parents.find(p=>p.id===otherId);
+  $$('#parents-list .parent-item').forEach(li=>li.classList.toggle('active', li.dataset.id===otherId));
+  currentMessages = [];
+  $('#conversation').innerHTML='';
+  await fetchConversation(otherId);
+  setupMessageSubscription(otherId);
+  await markNotificationsRead(otherId);
+}
+
+async function fetchConversation(otherId){
+  const { data, error } = await supabase
+    .from('messages')
+    .select('id,sender_id,receiver_id,content,created_at')
+    .or(`and(sender_id.eq.${user.id},receiver_id.eq.${otherId}),and(sender_id.eq.${otherId},receiver_id.eq.${user.id})`)
+    .order('created_at', { ascending:true });
+  if(error){ console.error('load messages', error); return; }
+  currentMessages = data || [];
+  renderMessages();
+}
+
+function renderMessages(){
+  const wrap = $('#conversation');
+  wrap.innerHTML='';
+  currentMessages.forEach(m=>{
+    const mine = m.sender_id===user.id;
+    const line = document.createElement('div');
+    line.className = 'chat-line ' + (mine? 'user':'assistant');
+    line.innerHTML = `\n      <div class="avatar">${mine? 'Moi' : (activeParent?.full_name?.[0]||'')}</div>\n      <div class="message"><div class="bubble ${mine?'user':'assistant'}">${escapeHTML(m.content)}</div></div>`;
+    wrap.appendChild(line);
+  });
+  wrap.scrollTop = wrap.scrollHeight;
+}
+
+$('#message-form').addEventListener('submit', async e=>{
+  e.preventDefault();
+  if(!activeParent) return;
+  const textarea = $('#message-input');
+  const content = textarea.value.trim();
+  if(!content) return;
+  textarea.value='';
+  const { data, error } = await supabase
+    .from('messages')
+    .insert({ sender_id:user.id, receiver_id:activeParent.id, content })
+    .select()
+    .single();
+  if(error){ console.error('send message', error); return; }
+  currentMessages.push(data);
+  renderMessages();
+  await supabase.from('notifications').insert({ user_id:activeParent.id, type:'message', reference_id:data.id, is_read:false });
+});
+
+function setupMessageSubscription(otherId){
+  if(messagesChannel) supabase.removeChannel(messagesChannel);
+  messagesChannel = supabase
+    .channel('room-'+otherId)
+    .on('postgres_changes', { event:'INSERT', schema:'public', table:'messages' }, payload => {
+      const m = payload.new;
+      if((m.sender_id===user.id && m.receiver_id===otherId) || (m.sender_id===otherId && m.receiver_id===user.id)){
+        currentMessages.push(m); renderMessages();
+      }
+    })
+    .subscribe();
+}
+
+async function loadNotifications(){
+  const { data, error } = await supabase
+    .from('notifications')
+    .select('id,is_read,reference_id,created_at,messages(id,sender_id,content,profiles(full_name,avatar_url))')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending:false });
+  if(!error){ notifications = data||[]; renderNotifications(); }
+}
+
+function renderNotifications(){
+  const count = notifications.filter(n=>!n.is_read).length;
+  $('#notif-count').textContent = count ? String(count) : '';
+  const list = $('#notif-list');
+  list.innerHTML='';
+  notifications.forEach(n=>{
+    const msg = n.messages;
+    const sender = msg?.profiles?.full_name || 'Parent';
+    const snippet = msg?.content?.slice(0,50) || '';
+    const item = document.createElement('div');
+    item.className='notif-item '+(n.is_read?'read':'unread');
+    item.dataset.id=n.id;
+    item.dataset.sender=msg?.sender_id;
+    item.innerHTML = `<strong>${sender}</strong><div class="notif-snippet">${escapeHTML(snippet)}</div>`;
+    item.addEventListener('click', async ()=>{
+      await supabase.from('notifications').update({ is_read:true }).eq('id', n.id);
+      await loadNotifications();
+      openConversation(item.dataset.sender);
+      $('#notif-list').hidden = true;
+    });
+    list.appendChild(item);
+  });
+  if(!notifications.length) list.textContent='Aucune notification';
+}
+
+function setupNotifButton(){
+  $('#notif-btn').addEventListener('click', e=>{
+    e.preventDefault();
+    const panel = $('#notif-list');
+    panel.hidden = !panel.hidden;
+  });
+}
+
+async function markNotificationsRead(otherId){
+  const ids = currentMessages.filter(m=>m.sender_id===otherId).map(m=>m.id);
+  if(!ids.length) return;
+  await supabase
+    .from('notifications')
+    .update({ is_read:true })
+    .eq('user_id', user.id)
+    .eq('type','message')
+    .in('reference_id', ids);
+  loadNotifications();
+}
+
+function setupSubscriptions(){
+  notifChannel = supabase
+    .channel('notif-'+user.id)
+    .on('postgres_changes', { event:'INSERT', schema:'public', table:'notifications', filter:`user_id=eq.${user.id}` }, loadNotifications)
+    .on('postgres_changes', { event:'UPDATE', schema:'public', table:'notifications', filter:`user_id=eq.${user.id}` }, loadNotifications)
+    .subscribe();
+}
+
+init();

--- a/messages.html
+++ b/messages.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Messages privés</title>
+  <link rel="stylesheet" href="assets/style.css?v=6" />
+  <style>
+    .chat-area{display:flex;gap:20px;margin-top:20px}
+    .parent-list{flex:0 0 200px;max-height:70vh;overflow-y:auto}
+    .parent-item{display:flex;align-items:center;gap:8px;padding:8px;cursor:pointer}
+    .parent-item.active{background:rgba(255,255,255,.1)}
+    .chat-window{flex:1;display:flex;flex-direction:column;max-height:70vh}
+    #conversation{flex:1;overflow-y:auto}
+    #notif-list{position:absolute;right:20px;top:60px;width:300px;max-height:400px;overflow-y:auto;z-index:1000}
+    #notif-list .notif-item{padding:8px 12px;border-bottom:1px solid rgba(0,0,0,.1);cursor:pointer}
+    #notif-list .notif-item.unread{background:rgba(255,255,255,.1)}
+    #notif-list .notif-item.read{opacity:.6}
+    #notif-count{font-weight:bold;margin-left:4px}
+  </style>
+</head>
+<body class="no-js">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="index.html">
+        <img src="/logotexte.png" alt="Synap'Kids" width="200" height="40" class="brand-text-logo" />
+      </a>
+      <nav id="main-nav" class="main-nav" aria-label="Navigation principale">
+        <a href="index.html" class="nav-link"><span class="nav-ico">🏠</span><span>Accueil</span></a>
+        <a href="#" id="notif-btn" class="nav-link" role="button"><span class="nav-ico">🔔</span><span id="notif-count"></span></a>
+      </nav>
+      <div id="notif-list" class="card" hidden></div>
+    </div>
+  </header>
+  <main class="container">
+    <div class="chat-area">
+      <aside class="parent-list card">
+        <ul id="parents-list" class="stack"></ul>
+      </aside>
+      <section class="chat-window card">
+        <div id="conversation" class="chat-messages"></div>
+        <form id="message-form" class="chat-input" autocomplete="off">
+          <div class="chat-row">
+            <textarea id="message-input" class="chat-textarea" rows="1" placeholder="Écris ici…" required></textarea>
+            <button class="btn btn-primary chat-send" type="submit">Envoyer</button>
+          </div>
+        </form>
+      </section>
+    </div>
+  </main>
+  <script type="module" src="assets/messages.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `messages.html` page for private messaging between parents
- integrate Supabase to list profiles, exchange messages, and show notifications
- include realtime updates for messages and notification counter

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5731080908321ad0214023bc0e4a1