### PR TITLE
feat: add conversation list and community message links

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1784,8 +1784,9 @@ try {
             <div class="hstack"><span class="chip">${escapeHtml(cat)}</span><span class="muted" title="Auteur">${escapeHtml(author)}</span></div>
           </div>
           <p>${escapeHtml(t.content)}</p>
+          <a href="messages.html?user=${t.user_id}" class="btn btn-secondary btn-message">💬 Message privé</a>
           <div class="stack">
-            ${rs.map(r=>`<div class="reply"><div class="muted">${escapeHtml(authorsMap.get(r.user_id)||'Anonyme')} • ${new Date(r.created_at).toLocaleString()}</div><div>${escapeHtml(r.content)}</div></div>`).join('')}
+            ${rs.map(r=>`<div class="reply"><div class="muted">${escapeHtml(authorsMap.get(r.user_id)||'Anonyme')} • ${new Date(r.created_at).toLocaleString()} <a href="messages.html?user=${r.user_id}" class="btn btn-secondary btn-message" style="margin-left:8px">💬 Message privé</a></div><div>${escapeHtml(r.content)}</div></div>`).join('')}
           </div>
           <form data-id="${t.id}" class="form-reply form-grid" style="margin-top:8px">
             <label>Réponse<textarea name="content" rows="2" required></textarea></label>

--- a/messages.html
+++ b/messages.html
@@ -7,9 +7,13 @@
   <link rel="stylesheet" href="assets/style.css?v=6" />
   <style>
     .chat-area{display:flex;gap:20px;margin-top:20px}
-    .parent-list{flex:0 0 200px;max-height:70vh;overflow-y:auto}
-    .parent-item{display:flex;align-items:center;gap:8px;padding:8px;cursor:pointer}
+    .parent-list{flex:0 0 250px;max-height:70vh;overflow-y:auto}
+    .parent-item{display:flex;align-items:flex-start;gap:8px;padding:8px;cursor:pointer}
     .parent-item.active{background:rgba(255,255,255,.1)}
+    .parent-item .meta{flex:1}
+    .parent-item .name{font-weight:600}
+    .parent-item .last-msg{font-size:.875rem;color:var(--muted,#666)}
+    .parent-item .last-msg time{display:block;font-size:.75rem;opacity:.7}
     .chat-window{flex:1;display:flex;flex-direction:column;max-height:70vh}
     #conversation{flex:1;overflow-y:auto}
     #notif-list{position:absolute;right:20px;top:60px;width:300px;max-height:400px;overflow-y:auto;z-index:1000}


### PR DESCRIPTION
## Summary
- show conversation list with last messages and timestamps
- open chat via "Message privé" buttons on community posts and replies
- support direct chat links and realtime list updates

## Testing
- `node --check assets/messages.js`
- `node --check assets/app.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c577e60e088321a13c884f1fa7bcc6