### PR TITLE
fix: allow messaging any user

### DIFF
--- a/assets/messages.js
+++ b/assets/messages.js
@@ -91,12 +91,12 @@ function renderParentList(){
 async function ensureConversation(otherId){
   const id = idStr(otherId);
   if(parents.some(p=>p.id===id)) return;
-  const { data, error } = await supabase.from('profiles').select('id,full_name,avatar_url').eq('id', id).single();
-  if(!error && data){
-    parents.push({ ...data, id });
-    lastMessages.set(id, null);
-    renderParentList();
-  }
+  let profile = { id, full_name:'Parent', avatar_url:null };
+  const { data } = await supabase.from('profiles').select('id,full_name,avatar_url').eq('id', id).single();
+  if(data) profile = { ...data, id:idStr(data.id) };
+  parents.push(profile);
+  lastMessages.set(id, null);
+  renderParentList();
 }
 
 async function openConversation(otherId){


### PR DESCRIPTION
## Summary
- ensure messaging view always has a profile entry for a targeted user

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c57d5f6088832199d84b4491040318