### PR TITLE
fix: normalize sent message IDs

### DIFF
--- a/assets/messages.js
+++ b/assets/messages.js
@@ -154,11 +154,18 @@ $('#message-form').addEventListener('submit', async e=>{
     .select()
     .single();
   if(error){ console.error('send message', error); return; }
-  currentMessages.push(data);
+  const msg = {
+    ...data,
+    sender_id: idStr(data.sender_id),
+    receiver_id: idStr(data.receiver_id)
+  };
+  currentMessages.push(msg);
   renderMessages();
-  lastMessages.set(activeParent.id, data);
+  lastMessages.set(activeParent.id, msg);
   renderParentList();
-  await supabase.from('notifications').insert({ user_id:activeParent.id, type:'message', reference_id:data.id, is_read:false });
+  await supabase
+    .from('notifications')
+    .insert({ user_id: activeParent.id, type: 'message', reference_id: data.id, is_read: false });
 });
 
 function setupMessageSubscription(otherId){


### PR DESCRIPTION
## Summary
- ensure sent messages have string sender and receiver IDs so they appear for both users

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5841c70ac83219e5bb59212f2ec53