### PR TITLE
fix: place chat window below conversation on mobile

### DIFF
--- a/messages.html
+++ b/messages.html
@@ -21,6 +21,11 @@
     #notif-list .notif-item.unread{background:rgba(255,255,255,.1)}
     #notif-list .notif-item.read{opacity:.6}
     #notif-count{font-weight:bold;margin-left:4px}
+    @media(max-width:600px){
+      .chat-area{flex-direction:column}
+      .parent-list{flex:0 0 auto;width:100%;max-height:40vh}
+      .chat-window{flex:1 1 auto;width:100%;max-height:60vh}
+    }
   </style>
 </head>
 <body class="no-js">


### PR DESCRIPTION
## Summary
- Stack chat list and conversation vertically on narrow screens for better mobile usability

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5895d63488321a1c5c8dcaf61d03a