### PR TITLE
feat: add parent nickname

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,6 +442,9 @@
         <div class="grid-2">
           <form id="form-settings" class="card form-grid">
             <h3>Profil parent</h3>
+            <label>Pseudo
+              <input type="text" name="pseudo" maxlength="30" />
+            </label>
             <label>Rôle affiché
               <select name="role">
                 <option value="maman">Maman</option>


### PR DESCRIPTION
## Summary
- allow parents to pick a nickname in settings
- save nickname to Supabase profile and local store
- display chosen nickname in community posts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check assets/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c58b77a7d48321a01321307e968070