### PR TITLE
Align message page header and footer with main site

### DIFF
--- a/messages.html
+++ b/messages.html
@@ -31,16 +31,34 @@
 <body class="no-js">
   <header class="site-header">
     <div class="container header-inner">
-      <a class="brand" href="index.html">
-        <img src="/logotexte.png" alt="Synap'Kids" width="200" height="40" class="brand-text-logo" />
+      <a class="brand" href="index.html#/">
+        <img src="/logotexte.png" alt="Synap'Kids" width="377" height="74" decoding="async" fetchpriority="high" class="brand-text-logo" />
       </a>
       <nav id="main-nav" class="main-nav" aria-label="Navigation principale">
-        <a href="index.html" class="nav-link"><span class="nav-ico">🏠</span><span>Accueil</span></a>
+        <a href="index.html#/" class="nav-link"><span class="nav-ico">🏠</span><span>Accueil</span></a>
+        <a href="index.html#/dashboard" class="nav-link"><span class="nav-ico">📊</span><span>Dashboard</span></a>
+        <a href="index.html#/community" class="nav-link"><span class="nav-ico">💬</span><span>Communauté</span></a>
+        <a href="messages.html" class="nav-link"><span class="nav-ico">📨</span><span>Messages</span></a>
+        <a href="index.html#/ai" class="nav-link"><span class="nav-ico">🤖</span><span>Fonctionnalité IA</span></a>
+        <a href="index.html#/settings" class="nav-link"><span class="nav-ico">⚙️</span><span>Paramètres</span></a>
+        <a href="index.html#/about" class="nav-link"><span class="nav-ico">ℹ️</span><span>À propos</span></a>
         <a href="#" id="notif-btn" class="nav-link" role="button"><span class="nav-ico">🔔</span><span id="notif-count"></span></a>
       </nav>
+      <div class="auth-actions">
+        <button id="nav-toggle" class="nav-toggle" aria-controls="main-nav" aria-expanded="false" title="Menu">☰</button>
+        <span id="login-status" class="login-status" hidden>connecté</span>
+        <button id="btn-login" class="btn btn-secondary">Se connecter</button>
+        <button id="btn-logout" class="btn btn-secondary" hidden>Se déconnecter</button>
+      </div>
       <div id="notif-list" class="card" hidden></div>
     </div>
   </header>
+  <div id="page-logo" class="page-logo" hidden>
+    <div class="container">
+      <img src="/logo.png" alt="Logo" class="page-logo-img" loading="lazy" decoding="async" />
+    </div>
+  </div>
+  <div id="nav-backdrop" class="nav-backdrop" aria-hidden="true"></div>
   <main class="container">
     <div class="chat-area">
       <aside class="parent-list card">
@@ -57,6 +75,27 @@
       </section>
     </div>
   </main>
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-simple">
+        <div class="fs-left">
+          <a class="brand" href="index.html#/" aria-label="Accueil Synap'Kids">
+            <span class="brand-text"><span class="brand-synap">Synap'</span><span class="brand-kids">Kids</span></span>
+          </a>
+          <p class="fs-tag">Le copilote parental 0–3 ans</p>
+        </div>
+        <div class="fs-right">
+          <a class="fs-link" href="index.html#/about">À propos</a>
+          <a class="fs-link" href="index.html#/contact">Contact</a>
+          <a class="fs-link" href="index.html#/legal">Mentions légales</a>
+          <a class="fs-link" href="index.html#/legal">Confidentialité</a>
+        </div>
+      </div>
+      <div class="footer-simple">
+        <span class="fs-year">© <span id="y"></span> <span class="brand-synap">Synap'</span><span class="brand-kids">Kids</span> — Infos indicatives, pas de conseil médical</span>
+      </div>
+    </div>
+  </footer>
   <script type="module" src="assets/messages.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Use the same site-wide header/navigation and footer on `messages.html`
- Add header auth state handling and mobile menu toggle to `messages.js`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c59015376c83218823b7c209122702