### PR TITLE
Fix mobile header on messages page

### DIFF
--- a/messages.html
+++ b/messages.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Messages privés</title>
   <link rel="stylesheet" href="assets/style.css?v=6" />
   <style>


### PR DESCRIPTION
## Summary
- ensure messages page meta viewport matches other pages
- add responsive header evaluation and mobile menu handling for messages page

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check assets/messages.js`


------
https://chatgpt.com/codex/tasks/task_e_68c592f6151083218d37a10475afdbc3