### PR TITLE
fix: unblock header and footer on messages page

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -395,9 +395,12 @@ try {
       // Dashboard: use fixed, full-viewport canvas so bubbles cover the whole page
       if (isDashboard) {
         cvs.className = 'route-canvas route-canvas-fixed';
+        // Prevent canvas from blocking UI elements
+        cvs.style.pointerEvents = 'none';
         document.body.prepend(cvs);
       } else {
         cvs.className = 'route-canvas';
+        cvs.style.pointerEvents = 'none';
         route.prepend(cvs);
       }
       const width = isDashboard ? window.innerWidth : route.clientWidth;

--- a/assets/messages.js
+++ b/assets/messages.js
@@ -102,6 +102,8 @@ function startRouteParticles(){
     if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
     const cvs = document.createElement('canvas');
     cvs.className = 'route-canvas route-canvas-fixed';
+    // Ensure background canvas never blocks interactions
+    cvs.style.pointerEvents = 'none';
     document.body.prepend(cvs);
     const ctx = cvs.getContext('2d');
     const state = routeParticles;
@@ -166,6 +168,8 @@ function startLogoParticles(){
     if(!wrap) return;
     const cvs = document.createElement('canvas');
     cvs.className='logo-canvas';
+    // Canvas is decorative; it must not intercept clicks
+    cvs.style.pointerEvents = 'none';
     wrap.prepend(cvs);
     const ctx = cvs.getContext('2d');
     const state = logoParticles;


### PR DESCRIPTION
## Summary
- prevent decorative background canvases from intercepting clicks
- ensure page logo particles are non-interactive

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c59a6951708321a63eb8cca2edeb8a