### PR TITLE
Fix navigation links on messages page

### DIFF
--- a/messages.html
+++ b/messages.html
@@ -26,17 +26,17 @@
 <body class="no-js">
   <header class="site-header">
     <div class="container header-inner">
-      <a class="brand" href="#/">
+      <a class="brand" href="/#/">
         <img src="/logotexte.png" alt="Synap'Kids" width="377" height="74" decoding="async" fetchpriority="high" class="brand-text-logo" />
       </a>
       <nav id="main-nav" class="main-nav" aria-label="Navigation principale">
-        <a href="#/" class="nav-link"><span class="nav-ico">🏠</span><span>Accueil</span></a>
-        <a href="#/dashboard" class="nav-link"><span class="nav-ico">📊</span><span>Dashboard</span></a>
-        <a href="#/community" class="nav-link"><span class="nav-ico">💬</span><span>Communauté</span></a>
+        <a href="/#/" class="nav-link"><span class="nav-ico">🏠</span><span>Accueil</span></a>
+        <a href="/#/dashboard" class="nav-link"><span class="nav-ico">📊</span><span>Dashboard</span></a>
+        <a href="/#/community" class="nav-link"><span class="nav-ico">💬</span><span>Communauté</span></a>
         <a href="messages.html" class="nav-link"><span class="nav-ico">📨</span><span>Messages</span></a>
-        <a href="#/ai" class="nav-link"><span class="nav-ico">🤖</span><span>Fonctionnalité IA</span></a>
-        <a href="#/settings" class="nav-link"><span class="nav-ico">⚙️</span><span>Paramètres</span></a>
-        <a href="#/about" class="nav-link"><span class="nav-ico">ℹ️</span><span>À propos</span></a>
+        <a href="/#/ai" class="nav-link"><span class="nav-ico">🤖</span><span>Fonctionnalité IA</span></a>
+        <a href="/#/settings" class="nav-link"><span class="nav-ico">⚙️</span><span>Paramètres</span></a>
+        <a href="/#/about" class="nav-link"><span class="nav-ico">ℹ️</span><span>À propos</span></a>
       </nav>
       <div class="auth-actions">
         <button id="nav-toggle" class="nav-toggle" aria-controls="main-nav" aria-expanded="false" title="Menu">☰</button>
@@ -72,16 +72,16 @@
     <div class="container">
       <div class="footer-simple">
         <div class="fs-left">
-          <a class="brand" href="#/" aria-label="Accueil Synap'Kids">
+          <a class="brand" href="/#/" aria-label="Accueil Synap'Kids">
             <span class="brand-text"><span class="brand-synap">Synap'</span><span class="brand-kids">Kids</span></span>
           </a>
           <p class="fs-tag">Le copilote parental 0–3 ans</p>
         </div>
         <div class="fs-right">
-          <a class="fs-link" href="#/about">À propos</a>
-          <a class="fs-link" href="#/contact">Contact</a>
-          <a class="fs-link" href="#/legal">Mentions légales</a>
-          <a class="fs-link" href="#/legal">Confidentialité</a>
+          <a class="fs-link" href="/#/about">À propos</a>
+          <a class="fs-link" href="/#/contact">Contact</a>
+          <a class="fs-link" href="/#/legal">Mentions légales</a>
+          <a class="fs-link" href="/#/legal">Confidentialité</a>
         </div>
       </div>
       <div class="footer-simple">


### PR DESCRIPTION
## Summary
- Make header and hamburger menu links on messages page point to main app routes
- Ensure footer brand and links navigate correctly to the main app

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c59cae3bf08321a2bc95030fecf29f