### PR TITLE
fix: delete chat conversation from supabase

### DIFF
--- a/assets/messages.js
+++ b/assets/messages.js
@@ -323,17 +323,22 @@ async function ensureConversation(otherId){
 async function deleteConversation(otherId){
   const id = idStr(otherId);
   if(!confirm('Supprimer cette conversation ?')) return;
-  await supabase
+  const { error } = await supabase
     .from('messages')
     .delete()
     .or(`and(sender_id.eq.${user.id},receiver_id.eq.${id}),and(sender_id.eq.${id},receiver_id.eq.${user.id})`);
+  if(error){
+    console.error('delete conv', error);
+    alert('Erreur lors de la suppression.');
+    return;
+  }
   parents = parents.filter(p=>p.id!==id);
   lastMessages.delete(id);
   if(activeParent?.id===id){
     activeParent=null;
     currentMessages=[];
     $('#conversation').innerHTML='';
-    if(messagesChannel) supabase.removeChannel(messagesChannel);
+    if(messagesChannel) await supabase.removeChannel(messagesChannel);
     messagesChannel=null;
   }
   renderParentList();


### PR DESCRIPTION
## Summary
- ensure conversations can be fully deleted from Supabase
- handle errors and cleanup chat channel after deletion

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5a18078cc8321a912bb3d7907e1a3