### PR TITLE
fix: prevent community duplicates

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1747,6 +1747,8 @@ try {
 
   // Community
   function renderCommunity() {
+    // Render instance guard to avoid race conditions and duplicate DOM nodes
+    const rid = (renderCommunity._rid = (renderCommunity._rid || 0) + 1);
     const list = $('#forum-list');
     list.innerHTML = '';
     // Category filter handlers
@@ -1763,6 +1765,7 @@ try {
     }
     const activeCat = cats?.getAttribute('data-active') || 'all';
     const showEmpty = () => {
+      if (rid !== renderCommunity._rid) return;
       const empty = document.createElement('div');
       empty.className = 'card';
       empty.textContent = 'Aucun sujet pour le moment. Lancez la discussion !';
@@ -1770,6 +1773,7 @@ try {
     };
     const renderTopics = (topics, replies, authorsMap) => {
       if (!topics.length) return showEmpty();
+      if (rid !== renderCommunity._rid) return;
       topics.slice().forEach(t => {
         // Extract category from title prefix like [Sommeil] Titre
         let title = t.title || '';


### PR DESCRIPTION
## Summary
- avoid race conditions in community rendering by tracking render instance
- skip outdated renders to stop duplicate topics and empty messages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5a5a543ac8321a76c5ef7ef8a4bf1