### PR TITLE
style: refine conversation preview layout

### DIFF
--- a/assets/messages.js
+++ b/assets/messages.js
@@ -451,12 +451,11 @@ function renderParentList(){
     const li = document.createElement('li');
     li.className='parent-item';
     li.dataset.id = p.id;
-    const snippet = last? escapeHTML(last.content.slice(0,50)) : 'Aucun message';
     const time = last? new Date(last.created_at).toLocaleString() : '';
     li.innerHTML = `
       <div class="meta">
         <div class="name">${escapeHTML(p.full_name||'Parent')}</div>
-        <div class="last-msg">${snippet}${time?`<br><time>${time}</time>`:''}</div>
+        ${time?`<time>${time}</time>`:''}
       </div>
       <button class="del-btn" title="Supprimer">✖</button>`;
     li.addEventListener('click', ()=>openConversation(p.id));

--- a/messages.html
+++ b/messages.html
@@ -8,12 +8,12 @@
   <style>
     .chat-area{display:flex;gap:20px;margin-top:20px}
     .parent-list{flex:0 0 250px;max-height:70vh;overflow-y:auto}
-    .parent-item{display:flex;align-items:flex-start;gap:8px;padding:8px;cursor:pointer}
+    #parents-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:12px}
+    .parent-item{display:flex;align-items:flex-start;gap:8px;padding:8px;cursor:pointer;border-radius:12px;width:100%}
     .parent-item.active{background:rgba(255,255,255,.1)}
     .parent-item .meta{flex:1}
     .parent-item .name{font-weight:600}
-    .parent-item .last-msg{font-size:.875rem;color:var(--muted,#666)}
-    .parent-item .last-msg time{display:block;font-size:.75rem;opacity:.7}
+    .parent-item time{display:block;font-size:.75rem;opacity:.7;color:var(--muted,#666)}
     .parent-item .del-btn{background:none;border:none;color:var(--muted,#666);cursor:pointer;padding:2px;margin-left:auto}
     .parent-item .del-btn:hover{color:#c00}
     .chat-window{flex:1;display:flex;flex-direction:column;max-height:70vh}
@@ -57,7 +57,7 @@
   <main class="container">
     <div class="chat-area">
       <aside class="parent-list card">
-        <ul id="parents-list" class="stack"></ul>
+        <ul id="parents-list"></ul>
       </aside>
       <section class="chat-window card">
         <div id="conversation" class="chat-messages"></div>


### PR DESCRIPTION
## Summary
- round conversation cards and show timestamps only
- expand conversation list items to card width

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5ec771d9c832193a52dd9fafc15fc