### PR TITLE
fix desktop message list overflow

### DIFF
--- a/messages.html
+++ b/messages.html
@@ -6,8 +6,8 @@
   <title>Messages privés</title>
   <link rel="stylesheet" href="assets/style.css?v=6" />
   <style>
-    .chat-area{display:flex;gap:20px;margin-top:20px}
-    .parent-list{flex:0 0 250px;max-height:70vh;overflow-y:auto}
+    .chat-area{display:flex;gap:20px;margin-top:20px;height:70vh}
+    .parent-list{flex:0 0 250px;height:100%;overflow-y:auto}
     #parents-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:12px}
     .parent-item{display:flex;align-items:flex-start;gap:8px;padding:8px;cursor:pointer;border-radius:12px;width:100%}
     .parent-item.active{background:rgba(255,255,255,.1)}
@@ -16,12 +16,12 @@
     .parent-item time{display:block;font-size:.75rem;opacity:.7;color:var(--muted,#666)}
     .parent-item .del-btn{background:none;border:none;color:var(--muted,#666);cursor:pointer;padding:2px;margin-left:auto}
     .parent-item .del-btn:hover{color:#c00}
-    .chat-window{flex:1;display:flex;flex-direction:column;max-height:70vh}
+    .chat-window{flex:1;display:flex;flex-direction:column;height:100%}
     #conversation{flex:1;overflow-y:auto}
     @media(max-width:600px){
-      .chat-area{flex-direction:column}
-      .parent-list{flex:0 0 auto;width:100%;max-height:40vh}
-      .chat-window{flex:1 1 auto;width:100%;max-height:60vh}
+      .chat-area{flex-direction:column;height:auto}
+      .parent-list{flex:0 0 auto;width:100%;max-height:40vh;height:auto}
+      .chat-window{flex:1 1 auto;width:100%;max-height:60vh;height:auto}
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- Match conversation list height with chat window on desktop
- Allow discussion list to scroll when overflowing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5f0e6a8f48321b1f51d7376ea28c9