### PR TITLE
Expand mobile chat window on small screens

### DIFF
--- a/messages.html
+++ b/messages.html
@@ -21,11 +21,11 @@
     .chat-placeholder{flex:1;display:flex;align-items:center;justify-content:center;height:100%;text-align:center}
     #conversation{flex:1;overflow-y:auto}
     @media(max-width:600px){
-      .chat-area{flex-direction:column;height:auto}
-      .parent-list{flex:0 0 auto;width:100%;max-height:40vh;height:auto}
-      .chat-window{flex:1 1 auto;width:100%;max-height:60vh;height:auto}
-      .chat-placeholder{flex:1 1 auto;width:100%;max-height:60vh;height:auto}
-    }
+        .chat-area{flex-direction:column;height:auto}
+        .parent-list{flex:0 0 auto;width:100%;max-height:30vh;height:auto}
+        .chat-window{flex:1 1 auto;width:100%;min-height:70vh;height:auto}
+        .chat-placeholder{flex:1 1 auto;width:100%;min-height:70vh;height:auto}
+      }
   </style>
 </head>
 <body class="no-js">


### PR DESCRIPTION
## Summary
- enlarge mobile chat window to a minimum of 70vh for better readability
- limit parent list to 30vh so chat area can occupy more space on phones

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5f87a8aec8321a5882b606b60e6b7