### PR TITLE
Use black text for sent messages

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -628,7 +628,7 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
 .chat-reset{justify-self:end}
 .bubble{max-width:100%; padding:12px 16px; border-radius:20px; line-height:1.4; color:#ffffff}
 .bubble.assistant{background:rgba(255,255,255,.08); border:none}
-.bubble.user{background:linear-gradient(135deg,var(--orange-strong),var(--violet-strong)); border:none}
+.bubble.user{background:linear-gradient(135deg,var(--orange-strong),var(--violet-strong)); border:none; color:#000}
 .chat-messages .meta{font-size:11px; color:var(--muted); margin-bottom:2px}
 .chat-line.user .meta{text-align:right}
 .typing{display:flex; gap:4px}

--- a/messages.html
+++ b/messages.html
@@ -20,8 +20,8 @@
     .chat-window.open{display:flex}
     .chat-placeholder{flex:1;display:flex;align-items:center;justify-content:center;height:100%;text-align:center}
     #conversation{flex:1;overflow-y:auto}
-    /* Make my sent bubbles slightly translucent (more opaque than before) */
-    .chat-window .bubble.user{opacity:.8}
+    /* Ensure my sent bubbles use solid black text */
+    .chat-window .bubble.user{color:#000}
     /* Small green dot for unread conversations */
     .dot-unread{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--ok,#2dc07a);box-shadow:0 0 0 2px rgba(255,255,255,.12)}
     @media(max-width:600px){


### PR DESCRIPTION
## Summary
- Render sent message bubbles with black text
- Update chat page style to remove opacity and ensure black text

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c606efe2ac8321a1dcc8a9c6151be7