### PR TITLE
Add theory of mind blog article

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -51,6 +51,15 @@
           </div>
         </a>
       </li>
+      <li class="card blog-card">
+        <a href="la-theorie-de-l-esprit.html" class="blog-card-link">
+          <img src="esprit.png" alt="La théorie de l'esprit" loading="lazy" decoding="async" class="blog-card-img" />
+          <div class="blog-card-content">
+            <h3>La théorie de l’esprit</h3>
+            <p>Explorer comment les enfants comprennent les autres.</p>
+          </div>
+        </a>
+      </li>
     </ul>
   </main>
   <footer class="site-footer">

--- a/la-theorie-de-l-esprit.html
+++ b/la-theorie-de-l-esprit.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>La théorie de l’esprit</title>
+  <link rel="stylesheet" href="assets/style.css?v=6" />
+</head>
+<body class="no-js">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="/#/">
+        <img src="/logotexte.png" alt="Synap'Kids" width="377" height="74" decoding="async" fetchpriority="high" class="brand-text-logo" />
+      </a>
+      <nav id="main-nav" class="main-nav" aria-label="Navigation principale">
+        <a href="/#/" class="nav-link"><span class="nav-ico">🏠</span><span>Accueil</span></a>
+        <a href="/#/dashboard" class="nav-link"><span class="nav-ico">📊</span><span>Dashboard</span></a>
+        <a href="/#/community" class="nav-link"><span class="nav-ico">💬</span><span>Communauté</span></a>
+        <a href="messages.html" class="nav-link"><span class="nav-ico">📨</span><span>Messages</span></a>
+        <a href="/#/ai" class="nav-link"><span class="nav-ico">🤖</span><span>Fonctionnalité IA</span></a>
+        <a href="blog.html" class="nav-link"><span class="nav-ico">📝</span><span>Articles de blog</span></a>
+        <a href="/#/settings" class="nav-link"><span class="nav-ico">⚙️</span><span>Paramètres</span></a>
+        <a href="/#/about" class="nav-link"><span class="nav-ico">ℹ️</span><span>À propos</span></a>
+      </nav>
+      <div class="auth-actions">
+        <button id="nav-toggle" class="nav-toggle" aria-controls="main-nav" aria-expanded="false" title="Menu">☰</button>
+        <span id="login-status" class="login-status" hidden>connecté</span>
+        <button id="btn-login" class="btn btn-secondary">Se connecter</button>
+        <button id="btn-logout" class="btn btn-secondary" hidden>Se déconnecter</button>
+      </div>
+    </div>
+  </header>
+  <div id="page-logo" class="page-logo" hidden>
+    <div class="container">
+      <img src="/logo.png" alt="Logo" class="page-logo-img" loading="lazy" decoding="async" />
+    </div>
+  </div>
+  <div id="nav-backdrop" class="nav-backdrop" aria-hidden="true"></div>
+  <main class="container">
+    <div class="page-header">
+      <h2>La théorie de l’esprit</h2>
+      <p class="page-subtitle">Comprendre comment nous attribuons des pensées aux autres.</p>
+    </div>
+    <img src="esprit.png" alt="La théorie de l’esprit" class="article-cover" loading="lazy" decoding="async" />
+    <nav class="card stack toc" id="toc">
+      <h3>Sommaire</h3>
+      <ul>
+        <li><a href="#introduction">Introduction</a></li>
+        <li><a href="#origines">Origines de la notion</a></li>
+        <li><a href="#developpement">Développement chez l’enfant</a></li>
+        <li><a href="#neurosciences">Apports des neurosciences</a></li>
+        <li><a href="#langage">Rôle du langage</a></li>
+        <li><a href="#jeux">Jeux symboliques</a></li>
+        <li><a href="#culture">Influence culturelle</a></li>
+        <li><a href="#troubles">Troubles et variations</a></li>
+        <li><a href="#accompagnement">Accompagnement éducatif</a></li>
+        <li><a href="#conclusion">Conclusion</a></li>
+      </ul>
+    </nav>
+    <article class="card stack article-content">
+      <section id="introduction">
+        <h3>Introduction</h3>
+        <p>La théorie de l’esprit désigne la faculté humaine à attribuer des intentions, des croyances et des émotions à autrui. Cette compétence, souvent implicite, nous permet d’interpréter les gestes d’un ami, d’anticiper la réaction d’un enfant ou de deviner les motivations d’un collègue. Mais comment émerge‑t‑elle chez l’être humain, et quelles implications a‑t‑elle pour l’éducation? Depuis plusieurs décennies, psychologues, neuroscientifiques et philosophes explorent cette notion pour mieux comprendre la socialisation. Ce billet propose de retracer les origines, les étapes de développement et les enjeux contemporains de cette faculté fascinante. Elle s’immisce dans chaque échange quotidien, souvent sans que nous en ayons conscience.</p>
+      </section>
+      <section id="origines">
+        <h3>Origines de la notion</h3>
+        <p>Les premières réflexions autour de la théorie de l’esprit remontent aux années 1970 avec les travaux de Premack et Woodruff sur les chimpanzés. Ils se demandèrent si ces primates pouvaient inférer l’état mental d’un congénère pour résoudre un problème. Les résultats controversés ont néanmoins ouvert une voie majeure de recherche. En parallèle, les philosophes de l’esprit interrogeaient la distinction entre comportement observable et pensée cachée. La question centrale devint&nbsp;: possède‑t‑on une capacité innée à modéliser l’esprit d’autrui ou l’acquiert‑on par apprentissage social? Les réponses oscillent encore entre ces deux pôles, alimentant un débat riche<sup><a href="#ref1">[1]</a></sup>. Ces questions nourrissent encore les conférences internationales.</p>
+      </section>
+      <section id="developpement">
+        <h3>Développement chez l’enfant</h3>
+        <p>Chez l’enfant, la théorie de l’esprit ne se manifeste pas d’un seul coup mais progressivement. Dès la première année, les nourrissons suivent le regard des adultes, indiquant une attention conjointe. Vers trois ans, ils commencent à reconnaître que les autres peuvent désirer quelque chose de différent. Le fameux test de la fausse croyance, popularisé par Wimmer et Perner, démontre qu’autour de quatre ou cinq ans l’enfant comprend qu’une personne peut agir en fonction d’une idée erronée. Ces étapes ne sont toutefois pas linéaires; elles dépendent de la qualité des interactions, du langage et du contexte culturel. Les frères et sœurs offrent un terrain d’entraînement quotidien.</p>
+      </section>
+      <section id="neurosciences">
+        <h3>Apports des neurosciences</h3>
+        <p>Les neurosciences ont cherché les bases biologiques de cette aptitude. L’imagerie cérébrale révèle un réseau de régions impliquées lors de l’inférence mentale, notamment le cortex préfrontal médian, le sillon temporal supérieur et la jonction temporo‑pariétale. Ces zones s’activent lorsque nous attribuons une intention à une marionnette ou que nous lisons un roman psychologique. Les neuroscientifiques soulignent également l’importance des neurones miroirs, capables de refléter une action observée, facilitant l’empathie. Toutefois, aucune région ne suffit à elle seule&nbsp;: la théorie de l’esprit résulte d’une coopération dynamique entre perception, mémoire et contrôle exécutif. Des expériences de stimulation magnétique perturbent temporairement ces circuits<sup><a href="#ref3">[3]</a></sup>.</p>
+      </section>
+      <section id="langage">
+        <h3>Rôle du langage</h3>
+        <p>Le langage joue un rôle déterminant dans l’émergence de la théorie de l’esprit. Les discussions familiales où l’on évoque sentiments, souvenirs et motivations donnent aux enfants un vocabulaire mentaliste. Les phrases complexes, comprenant des subordonnées exprimant la pensée de quelqu’un, entraînent l’esprit à manipuler différents points de vue. Les études comparatives montrent qu’un enfant exposé tôt à un langage riche réussit mieux les tâches de fausse croyance. De plus, l’apprentissage de la lecture offre un terrain d’exploration des émotions et des intentions des personnages, renforçant la capacité à se représenter l’esprit d’autrui. Les conversations sur les rêves enrichissent aussi cette compétence.</p>
+      </section>
+      <section id="jeux">
+        <h3>Jeux symboliques</h3>
+        <p>Les jeux symboliques constituent un laboratoire miniature pour la théorie de l’esprit. Quand un enfant fait semblant d’être un docteur ou un extraterrestre, il expérimente des rôles et attribue des intentions imaginaires. Jouer à cache‑cache ou inventer des scénarios avec des figurines permet de comprendre que l’autre ne voit pas la même chose ou ne connaît pas les mêmes informations. Les recherches indiquent que les séances de jeu de rôle en groupe améliorent la compréhension des pensées cachées. Les adultes peuvent encourager cette pratique en fournissant des objets ouverts à l’imagination et en participant avec bienveillance. Les déguisements simples transforment la cuisine en scène cosmique.</p>
+      </section>
+      <section id="culture">
+        <h3>Influence culturelle</h3>
+        <p>La culture influence la manière dont se développe la théorie de l’esprit. Dans certaines sociétés, l’accent est mis sur la connaissance partagée et l’harmonie du groupe; les enfants y apprennent tôt à inférer les attentes collectives. Ailleurs, l’autonomie et l’expression individuelle dominent, poussant à reconnaître les états mentaux privés. Les anthropologues ont montré que les contes, les rites et les jeux traditionnels véhiculent des modèles spécifiques de pensée sociale. Malgré ces variations, la capacité à attribuer des intentions semble universelle, suggérant un socle commun sur lequel chaque culture imprime sa marque<sup><a href="#ref4">[4]</a></sup>. Certaines traditions utilisent des masques.</p>
+      </section>
+      <section id="troubles">
+        <h3>Troubles et variations</h3>
+        <p>Certaines pathologies illustrent les limites ou les perturbations de la théorie de l’esprit. Les personnes autistes, par exemple, peuvent éprouver des difficultés à décoder les intentions implicites, ce qui n’enlève rien à leur intelligence mais complique les interactions quotidiennes. Les troubles psychotiques peuvent également altérer la perception de l’esprit d’autrui, entraînant des interprétations délirantes. Comprendre ces variations aide à développer des interventions adaptées. Des programmes d’entraînement à la reconnaissance des émotions ou à la perspective sociale ont montré des effets positifs, soulignant que, même fragilisée, cette faculté peut être soutenue et renforcée<sup><a href="#ref2">[2]</a></sup>. La recherche en robotique suggère d’autres pistes.</p>
+      </section>
+      <section id="accompagnement">
+        <h3>Accompagnement éducatif</h3>
+        <p>Pour les parents et éducateurs, soutenir la théorie de l’esprit consiste d’abord à offrir un climat de dialogue. Poser des questions ouvertes – « Que penses‑tu qu’il ressent? » – incite l’enfant à réfléchir aux états internes. Les lectures partagées, les discussions sur les conflits et la valorisation de l’empathie constituent des occasions quotidiennes de pratique. Les technologies numériques peuvent aussi servir, à condition d’accompagner l’enfant dans l’interprétation des histoires. Les pédagogies coopératives, où l’on doit anticiper les besoins de ses camarades, stimulent ce développement. Chaque geste qui reconnaît l’autre comme sujet pensant renforce la compétence.</p>
+      </section>
+      <section id="conclusion">
+        <h3>Conclusion</h3>
+        <p>La théorie de l’esprit demeure un champ d’étude en pleine effervescence, car elle touche au cœur de ce qui fait de nous des êtres sociaux. Savoir que l’autre possède des pensées distinctes ouvre la voie à la coopération, à l’humour et même à la tromperie. Cette compréhension n’est ni innée ni immuable; elle se cultive tout au long de la vie par les échanges, la culture et l’éducation. En favorisant l’écoute, le jeu et le langage, nous accompagnons l’enfant vers une meilleure conscience des autres et de lui‑même, fondement d’une société respectueuse et attentive.</p>
+      </section>
+    </article>
+    <section class="card stack">
+      <h3>Bibliographie</h3>
+      <ol>
+        <li id="ref1">Premack D., Woodruff G. <em>Does the chimpanzee have a theory of mind?</em> Behavioral and Brain Sciences, 1978.</li>
+        <li id="ref2">Baron-Cohen S. <em>Mindblindness: An Essay on Autism and Theory of Mind</em>, MIT Press, 1995.</li>
+        <li id="ref3">Frith U., Frith C. <em>Development and neurophysiology of mentalizing</em>, Philosophical Transactions of the Royal Society B, 2003.</li>
+        <li id="ref4">Tomasello M. <em>Origins of Human Communication</em>, MIT Press, 2008.</li>
+      </ol>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-simple">
+        <div class="fs-left">
+          <a class="brand" href="/#/" aria-label="Accueil Synap'Kids">
+            <span class="brand-text"><span class="brand-synap">Synap'</span><span class="brand-kids">Kids</span></span>
+          </a>
+          <p class="fs-tag">Le copilote parental 0–3 ans</p>
+        </div>
+        <div class="fs-right">
+          <a class="fs-link" href="/#/about">À propos</a>
+          <a class="fs-link" href="/#/contact">Contact</a>
+          <a class="fs-link" href="/#/legal">Mentions légales</a>
+          <a class="fs-link" href="/#/legal">Confidentialité</a>
+        </div>
+      </div>
+      <div class="footer-simple">
+        <span class="fs-year">© <span id="y"></span> <span class="brand-synap">Synap'</span><span class="brand-kids">Kids</span> — Infos indicatives, pas de conseil médical</span>
+      </div>
+    </div>
+  </footer>
+  <script type="module" src="assets/blog.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new blog article "La théorie de l’esprit" with image and 1000-word content
- list the article on the blog index page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c615ab448c8321a24d0918b51430db