### PR TITLE
Fix message button rendering on mobile

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -837,6 +837,12 @@ section[data-route="/community"] .btn-danger:hover{
 .topic .flex-between{ display:flex; align-items:center; justify-content:space-between; gap:8px }
 .topic .hstack{ display:flex; align-items:center; gap:8px }
 
+@media (max-width: 600px){
+  .btn-message{ flex-shrink:0 }
+  .topic .flex-between{ flex-wrap:wrap }
+  .topic .hstack{ flex-wrap:wrap }
+}
+
 /* Footer links (À propos, Contact, Mentions légales, Confidentialité) in orange and bold */
 .site-footer .fs-right .fs-link{ color: var(--orange-strong) !important; font-weight:700; }
 .site-footer .fs-right .fs-link:hover{ color: var(--orange-strong) !important; text-decoration: underline; }


### PR DESCRIPTION
## Summary
- prevent flex shrinking for private message button and allow topic headers to wrap on small screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c695025f0483219d412a9da897ab0c