### PR TITLE
Reduce mobile canvas opacity for bubbles

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -569,6 +569,8 @@ section[data-route="/"] > :nth-child(odd of .section)::before{
 .logo-canvas{position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:0; opacity:.6; mix-blend-mode:screen}
 /* Dashboard full-viewport canvas (fixed, no stretch) */
 .route-canvas-fixed{position:fixed; inset:0; width:100vw; height:100vh; pointer-events:none; z-index:0; opacity:.6; mix-blend-mode:screen}
+/* On mobile, reduce canvas opacity to keep bubbles subtle behind cards */
+@media(max-width:900px){.section-canvas,.route-canvas,.route-canvas-fixed,.logo-canvas{opacity:.3}}
 /* Ensure main content and footer sit above the fixed canvas */
 #app{position:relative; z-index:1}
 .site-footer{position:relative; z-index:1}


### PR DESCRIPTION
## Summary
- lower particle canvas opacity on mobile to prevent overly opaque bubbles behind cards

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6d275598083218fe9f3f44d4d8876