### PR TITLE
fix: move hero logo below card on mobile

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -323,6 +323,13 @@ section[data-route="/settings"] #form-settings textarea{
 .hero-v2 .orb2{ width:260px; height:260px; right:22%; bottom:-10%; background:radial-gradient(circle at 60% 40%, var(--blue-strong), transparent 60%); animation-delay:.6s }
 .hero-v2 .orb3{ width:140px; height:140px; right:-6%; top:36%; background:radial-gradient(circle at 40% 40%, var(--blue-pastel), transparent 60%); animation-delay:1.2s }
 
+.hero-v2-logo-mobile{ display:none; }
+@media(max-width:900px){
+  .hero-v2{ margin:8px 0 12px; }
+  .hero-v2-art{ display:none; }
+  .hero-v2-logo-mobile{ display:block; width:clamp(180px, 60vw, 320px); height:auto; margin:0 auto 24px; }
+}
+
 .mockup{position:relative; width:min(520px, 92%); border-radius:20px; padding:12px; background:linear-gradient(180deg, rgba(255,255,255,.14), rgba(255,255,255,.06)); border:1px solid rgba(255,255,255,.25); box-shadow:0 20px 50px rgba(0,0,0,.45); backdrop-filter:blur(14px) saturate(150%)}
 .mockup::before{content:""; position:absolute; inset:-4px; border-radius:22px; background:linear-gradient(120deg, rgba(142,125,255,.35), rgba(53,223,207,.28)); z-index:-1; filter:blur(10px); opacity:.8}
 .mockup-header{display:flex; gap:6px; padding:6px 6px 0}

--- a/index.html
+++ b/index.html
@@ -71,6 +71,8 @@
           </div>
         </div>
 
+        <img src="/logo.png" alt="Synap'Kids" class="hero-v2-logo-mobile" aria-hidden="true" />
+
         <div class="section">
           <h2 class="section-title">Fonctionnalités clés</h2>
           <p class="section-subtitle">Les outils essentiels pour un suivi simple et rassurant.</p>


### PR DESCRIPTION
## Summary
- move hero logo outside the hero card on mobile
- hide hero artwork and display logo below card with responsive CSS

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6e3934998832182f82705bc4dd078