### PR TITLE
Adjust mobile spacing around hero logo

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -327,7 +327,8 @@ section[data-route="/settings"] #form-settings textarea{
 @media(max-width:900px){
   .hero-v2{ margin:8px 0 12px; }
   .hero-v2-art{ display:none; }
-  .hero-v2-logo-mobile{ display:block; width:clamp(180px, 60vw, 320px); height:auto; margin:0 auto 24px; }
+  .hero-v2-logo-mobile{ display:block; width:clamp(180px, 60vw, 320px); height:auto; margin:0 auto 8px; }
+  .hero-v2-logo-mobile + .section{ padding-top:16px; }
 }
 
 .mockup{position:relative; width:min(520px, 92%); border-radius:20px; padding:12px; background:linear-gradient(180deg, rgba(255,255,255,.14), rgba(255,255,255,.06)); border:1px solid rgba(255,255,255,.25); box-shadow:0 20px 50px rgba(0,0,0,.45); backdrop-filter:blur(14px) saturate(150%)}


### PR DESCRIPTION
## Summary
- Tighten spacing after the mobile hero logo to bring the Features section closer.
- Reduce top padding on the first section when preceded by the mobile logo for better vertical rhythm on small screens.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6e66755088321a9387279b8097c09