### PR TITLE
feat: add subtle mobile bubbles on home

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -239,6 +239,10 @@ try {
       stopSectionParticles();
       startHeroParticles();
       stopLogoParticles();
+      // On mobile, also overlay the page with floating bubbles at low opacity
+      if (window.matchMedia && window.matchMedia('(max-width: 900px)').matches) {
+        startRouteParticles();
+      }
     } else {
       stopHeroParticles();
       stopSectionParticles();

--- a/assets/style.css
+++ b/assets/style.css
@@ -586,6 +586,9 @@ section[data-route="/"] > :nth-child(odd of .section)::before{
     opacity:.35 !important;
     mix-blend-mode: normal !important;
   }
+  section[data-route="/"] > .route-canvas{
+    opacity:.08 !important;
+  }
 }
 
 /* Hide homepage hero bubbles canvas only on smaller mobiles */


### PR DESCRIPTION
## Summary
- Overlay homepage with floating bubbles canvas on mobile
- Reduce homepage canvas opacity for a faint effect

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6ea62a9b48321b6ca7b72d576dc86