### PR TITLE
Increase canvas bubble opacity on non-home pages

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -573,11 +573,12 @@ section[data-route="/"] > :nth-child(odd of .section)::before{
 
 /* Canvas for section particles */
 /* Canvas layers: use normal blend by default so they remain visible on dark backgrounds */
-.section-canvas{position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:0; opacity:.7; mix-blend-mode:normal}
-.route-canvas{position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:0; opacity:.7; mix-blend-mode:normal}
-.logo-canvas{position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:0; opacity:.6; mix-blend-mode:screen}
+/* Increase default opacity of bubble canvases on non-home pages */
+.section-canvas{position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:0; opacity:.9; mix-blend-mode:normal}
+.route-canvas{position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:0; opacity:.9; mix-blend-mode:normal}
+.logo-canvas{position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:0; opacity:.8; mix-blend-mode:screen}
 /* Dashboard full-viewport canvas (fixed, no stretch) */
-.route-canvas-fixed{position:fixed; inset:0; width:100vw; height:100vh; pointer-events:none; z-index:0; opacity:.8; mix-blend-mode:screen}
+.route-canvas-fixed{position:fixed; inset:0; width:100vw; height:100vh; pointer-events:none; z-index:0; opacity:.95; mix-blend-mode:screen}
 
 section[data-route="/"] .section-canvas,
 section[data-route="/"] .route-canvas{
@@ -585,12 +586,12 @@ section[data-route="/"] .route-canvas{
 }
 /* On mobile, reduce canvas opacity and disable blend to avoid brightening under glass */
 @media(max-width:900px){
-  .section-canvas,
-  .route-canvas,
-  .route-canvas-fixed{
-    opacity:.5 !important;
-    mix-blend-mode: normal !important;
-  }
+    .section-canvas,
+    .route-canvas,
+    .route-canvas-fixed{
+      opacity:.7 !important;
+      mix-blend-mode: normal !important;
+    }
   section[data-route="/"] > .route-canvas{
     opacity:.08 !important;
   }


### PR DESCRIPTION
## Summary
- boost default opacity of non-home canvas bubbles
- raise mobile canvas opacity for non-home routes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ef8161008321b44faa22eaeb46c4