### PR TITLE
feat: mobile bubble canvases for key sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 
         <img src="/logo.png" alt="Synap'Kids" class="hero-v2-logo-mobile" aria-hidden="true" />
 
-        <div class="section">
+        <div class="section bubble-mobile">
           <h2 class="section-title">Fonctionnalités clés</h2>
           <p class="section-subtitle">Les outils essentiels pour un suivi simple et rassurant.</p>
           <div class="features">
@@ -98,7 +98,7 @@
           </div>
         </div>
 
-        <div class="section">
+        <div class="section bubble-mobile">
           <h2 class="section-title">Comment ça marche ?</h2>
           <p class="section-subtitle">Trois étapes claires pour démarrer en douceur.</p>
           <div class="steps">
@@ -129,7 +129,7 @@
           </div>
         </div>
 
-        <div class="section">
+        <div class="section bubble-mobile">
           <h2 class="section-title">Nos derniers articles</h2>
           <p class="section-subtitle">Un peu de documentation</p>
           <ul class="blog-list stack">
@@ -163,7 +163,7 @@
           </ul>
         </div>
 
-        <div class="section">
+        <div class="section bubble-mobile">
           <h2 class="section-title">Ils en parlent</h2>
           <p class="section-subtitle">Des retours de parents qui utilisent Synap'Kids au quotidien.</p>
           <div class="testimonials">
@@ -182,7 +182,7 @@
           </div>
         </div>
 
-        <div class="section">
+        <div class="section bubble-mobile">
           <h2 class="section-title">FAQ</h2>
           <p class="section-subtitle">Vos questions les plus fréquentes.</p>
           <div class="faq">
@@ -195,7 +195,7 @@
           </div>
         </div>
 
-        <div class="section">
+        <div class="section bubble-mobile">
           <h2 class="section-title">S’inscrire à la newsletter</h2>
           <p class="section-subtitle">Recevez les dernières nouvelles et conseils directement dans votre boîte mail.</p>
           <div class="cta-inner newsletter-cta">


### PR DESCRIPTION
## Summary
- render hero-style bubble canvases on mobile in features, steps, FAQ and newsletter sections
- ensure blog card bubble canvases scale with device pixel ratio to avoid deformation
- trigger section canvas setup on mobile home route

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6fe46b6748321b8a2d66c5cb610f3