### PR TITLE
feat: enable homepage bubble canvas on desktop

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -245,6 +245,8 @@ try {
         startSectionParticles();
         startCardParticles();
       } else {
+        // Desktop: apply bubble canvas across the entire homepage
+        startRouteParticles();
         stopCardParticles();
       }
     } else {


### PR DESCRIPTION
## Summary
- add route-wide bubble canvas to desktop homepage

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c7000d9ae48321a3dcd9bd780c959a