### PR TITLE
Add loading overlay with manual refresh option

### DIFF
--- a/assets/loading.js
+++ b/assets/loading.js
@@ -1,0 +1,20 @@
+(function(){
+  const overlay = document.getElementById('loading-overlay');
+  if(!overlay) return;
+  const refreshBtn = overlay.querySelector('#refresh-btn');
+  let done = false;
+  function hide(){
+    if(done) return;
+    done = true;
+    overlay.style.display = 'none';
+  }
+  window.addEventListener('load', hide);
+  setTimeout(() => {
+    if(!done){
+      if(refreshBtn){
+        refreshBtn.hidden = false;
+        refreshBtn.addEventListener('click', () => location.reload());
+      }
+    }
+  }, 5000);
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1116,3 +1116,26 @@ section[data-route="/community"] .btn-danger:hover{
 #toc li::before{content:counter(item) '.'; font-weight:600; margin-right:8px; color:var(--orange-strong);}
 #toc a{text-decoration:none; color:var(--blue-strong);}
 #toc a:hover{text-decoration:underline;}
+/* Loading overlay */
+#loading-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(255,255,255,0.8);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+#loading-overlay .loader {
+  width: 40px;
+  height: 40px;
+  border: 4px solid var(--border, #ccc);
+  border-top-color: var(--deep-blue, #4e7cd8);
+  border-radius: 50%;
+  animation: loading-spin 1s linear infinite;
+  margin-bottom: 1rem;
+}
+@keyframes loading-spin {
+  to { transform: rotate(360deg); }
+}

--- a/blog.html
+++ b/blog.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="assets/style.css?v=6" />
 </head>
 <body class="no-js">
+  <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Actualiser</button></div>
   <header class="site-header">
     <div class="container header-inner">
       <a class="brand" href="/#/">
@@ -92,6 +93,7 @@
       </div>
     </div>
   </footer>
+  <script src="assets/loading.js"></script>
   <script type="module" src="assets/blog.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="assets/style.css?v=7" />
   </head>
   <body class="no-js">
+  <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Actualiser</button></div>
     <header class="site-header">
       <div class="container header-inner">
         <a class="brand" href="#/">
@@ -578,6 +579,7 @@
       </div>
     </footer>
 
-    <script type="module" src="assets/app.js?v=2"></script>
+    <script src="assets/loading.js"></script>
+  <script type="module" src="assets/app.js?v=2"></script>
   </body>
   </html>

--- a/la-theorie-de-l-attachement.html
+++ b/la-theorie-de-l-attachement.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="assets/style.css?v=6" />
 </head>
 <body class="no-js">
+  <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Actualiser</button></div>
   <header class="site-header">
     <div class="container header-inner">
       <a class="brand" href="/#/">
@@ -125,6 +126,7 @@
       </div>
     </div>
   </footer>
+  <script src="assets/loading.js"></script>
   <script type="module" src="assets/blog.js"></script>
 </body>
 </html>

--- a/la-theorie-de-l-esprit.html
+++ b/la-theorie-de-l-esprit.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="assets/style.css?v=6" />
 </head>
 <body class="no-js">
+  <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Actualiser</button></div>
   <header class="site-header">
     <div class="container header-inner">
       <a class="brand" href="/#/">
@@ -130,6 +131,7 @@
       </div>
     </div>
   </footer>
+  <script src="assets/loading.js"></script>
   <script type="module" src="assets/blog.js"></script>
 </body>
 </html>

--- a/les-1000-premiers-jours.html
+++ b/les-1000-premiers-jours.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="assets/style.css?v=6" />
 </head>
 <body class="no-js">
+  <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Actualiser</button></div>
   <header class="site-header">
     <div class="container header-inner">
       <a class="brand" href="/#/">
@@ -125,6 +126,7 @@
       </div>
     </div>
   </footer>
+  <script src="assets/loading.js"></script>
   <script type="module" src="assets/blog.js"></script>
 </body>
 </html>

--- a/messages.html
+++ b/messages.html
@@ -33,6 +33,7 @@
   </style>
 </head>
 <body class="no-js">
+  <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Actualiser</button></div>
   <header class="site-header">
     <div class="container header-inner">
       <a class="brand" href="/#/">
@@ -108,6 +109,7 @@
       </div>
     </div>
   </footer>
+  <script src="assets/loading.js"></script>
   <script type="module" src="assets/messages.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a full-page loading overlay while content loads
- offer a manual refresh button if loading exceeds 5 seconds

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7134fb3e883219464ecd3fd455a25