### PR TITLE
fix: allow scrolling on mobile homepage

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -45,7 +45,7 @@
   font-display: swap;
 }
 *{box-sizing:border-box}
-html,body{height:100%; overflow-x:hidden}
+html,body{min-height:100%; overflow-x:hidden}
 html, body{ -ms-overflow-style:none; scrollbar-width:none }
 ::-webkit-scrollbar{ display:none }
 body{


### PR DESCRIPTION
## Summary
- ensure home page can scroll on mobile by replacing fixed height with min-height on root elements

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c743da31c48321a37d13cc5de163d7