### PR TITLE
Align home scroll behavior with other pages

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -200,7 +200,8 @@ try {
       if (pl) pl.hidden = (path === '/' || path === '');
     } catch {}
     updateHeaderAuth();
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    // Align scroll behavior with static pages (instant top reset)
+    window.scrollTo(0, 0);
     // Guard routes
     const authed = !!authSession?.user;
     const needAuth = ['/dashboard','/community','/ai','/settings','/onboarding'];


### PR DESCRIPTION
## Summary
- Use instant `window.scrollTo(0, 0)` when navigating routes so home page scrolling matches other pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7b80305cc8321aab8d038fbacc704