### PR TITLE
feat: separate child management and edit sections

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2785,7 +2785,11 @@ try {
         editBox.innerHTML = '<div class="muted">Sélectionnez un enfant pour modifier son profil.</div>';
       } else {
         editBox.innerHTML = `
-          <h3>Mettre à jour le profil enfant</h3>
+          <label>Enfant
+            <select id="child-select">
+              ${children.map(c=>`<option value="${c.id}" ${c.id===child.id?'selected':''}>${escapeHtml(c.first_name||c.firstName||'—')}</option>`).join('')}
+            </select>
+          </label>
           <form id="form-child-edit" class="form-grid" autocomplete="on">
             <input type="hidden" name="id" value="${child.id}" />
             <label>Prénom<input type="text" name="firstName" value="${escapeHtml(child.firstName)}" required /></label>
@@ -2870,6 +2874,14 @@ try {
             </div>
           </form>
         `;
+        const select = document.getElementById('child-select');
+        if (select && !select.dataset.bound) {
+          select.addEventListener('change', () => {
+            editBox.setAttribute('data-edit-id', select.value);
+            renderSettings();
+          });
+          select.dataset.bound = '1';
+        }
         // Bind submit
         const f = document.getElementById('form-child-edit');
         if (f && !f.dataset.bound) f.addEventListener('submit', async (e) => {

--- a/index.html
+++ b/index.html
@@ -548,9 +548,12 @@
           <div class="card stack">
             <h3>Gestion multi‑enfants</h3>
             <div id="children-list" class="stack"></div>
-            <div id="child-edit" class="stack"></div>
             <a class="btn btn-secondary" href="#/onboarding">Ajouter un profil enfant</a>
             <button id="btn-delete-account" class="btn btn-danger">Supprimer le compte</button>
+          </div>
+          <div class="card stack">
+            <h3>Mettre à jour le profil enfant</h3>
+            <div id="child-edit" class="stack"></div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- split multi-child management and child profile update into distinct cards
- add a child selector to the child profile update form

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7f98f168c8321b45a8eb4fe8797d3