### PR TITLE
Limit update history display with expandable view

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2026,6 +2026,21 @@ try {
           }).join('')}</div>`
         : `<div class="muted">Aucune mise à jour enregistrée pour l’instant.</div>`
       );
+      if (updates.length > 2) {
+        const stack = hist.querySelector('.stack');
+        const items = Array.from(stack.children);
+        items.forEach((el, idx) => {
+          if (idx >= 2) el.style.display = 'none';
+        });
+        const btn = document.createElement('button');
+        btn.className = 'btn btn-secondary';
+        btn.textContent = 'Tout afficher';
+        btn.addEventListener('click', () => {
+          items.forEach(el => { el.style.display = ''; });
+          btn.remove();
+        });
+        hist.appendChild(btn);
+      }
       dom.appendChild(hist);
     } catch {}
 


### PR DESCRIPTION
## Summary
- Show only the two latest updates in the dashboard history
- Add "Tout afficher" button to reveal older updates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c81a1741408321855515533ce06a84