### PR TITLE
feat: add manual refresh buttons

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2357,6 +2357,11 @@ try {
     const rid = (renderCommunity._rid = (renderCommunity._rid || 0) + 1);
     const list = $('#forum-list');
     list.innerHTML = '';
+    const refreshBtn = $('#btn-refresh-community');
+    if (refreshBtn && !refreshBtn.dataset.bound) {
+      refreshBtn.dataset.bound = '1';
+      refreshBtn.addEventListener('click', () => renderCommunity());
+    }
     // Category filter handlers
     const cats = $('#forum-cats');
     if (cats && !cats.dataset.bound) {
@@ -2627,6 +2632,11 @@ try {
     const form = $('#form-settings');
     form.role.value = user?.role || 'maman';
     form.pseudo.value = user?.pseudo || '';
+    const refreshBtn = $('#btn-refresh-settings');
+    if (refreshBtn && !refreshBtn.dataset.bound) {
+      refreshBtn.dataset.bound = '1';
+      refreshBtn.addEventListener('click', () => renderSettings());
+    }
     // Privacy & profile load
     (async () => {
       if (useRemote()) {

--- a/index.html
+++ b/index.html
@@ -367,6 +367,7 @@
               <button class="btn btn-secondary cat" data-cat="Développement">Développement</button>
               <button class="btn btn-secondary cat" data-cat="Divers">Divers</button>
             </div>
+            <button id="btn-refresh-community" class="btn btn-secondary">Rafraîchir</button>
             <button id="btn-new-topic" class="btn btn-primary">Nouveau sujet</button>
           </div>
         </div>
@@ -520,6 +521,9 @@
         <div class="page-header">
           <h2>Paramètres</h2>
           <p class="page-subtitle">Profil, confidentialité et gestion multi‑enfants.</p>
+          <div class="page-actions">
+            <button id="btn-refresh-settings" class="btn btn-secondary">Rafraîchir</button>
+          </div>
         </div>
         <div class="grid-2">
           <form id="form-settings" class="card form-grid">


### PR DESCRIPTION
## Summary
- add manual refresh button on community page
- allow settings page refresh to reload profile data

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c82941fa0c83219734c355bb29de56