### PR TITLE
Remove child avatar upload

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1788,11 +1788,6 @@ try {
         if (btn) { btn.disabled = true; btn.textContent = 'Chargement...'; }
         try {
           const fd = new FormData(form);
-          const file = fd.get('photo');
-          let photoDataUrl = null;
-          if (file instanceof File && file.size > 0) {
-            photoDataUrl = await fileToDataUrl(file);
-          }
           const dobStr = fd.get('dob').toString();
           const ageMAtCreation = ageInMonths(dobStr);
           const // read 30 booleans in displayed order (include false)
@@ -1806,7 +1801,7 @@ try {
             firstName: fd.get('firstName').toString().trim(),
             sex: fd.get('sex').toString(),
             dob: dobStr,
-            photo: photoDataUrl,
+            photo: null,
             context: {
               allergies: fd.get('allergies').toString(),
               history: fd.get('history').toString(),
@@ -1850,15 +1845,6 @@ try {
         }
       });
     }
-  }
-
-  function fileToDataUrl(file) {
-    return new Promise((res, rej) => {
-      const reader = new FileReader();
-      reader.onload = () => res(reader.result.toString());
-      reader.onerror = rej;
-      reader.readAsDataURL(file);
-    });
   }
 
   // Dashboard
@@ -2863,7 +2849,6 @@ try {
               <label>Poids (kg)<input type="number" step="0.01" name="weight" /></label>
             </div>
             <label>Dents (nb)<input type="number" step="1" name="teeth" /></label>
-            <label>Photo/avatar<input type="file" name="photo" accept="image/*" /></label>
             <h4>Contexte</h4>
             <label>Allergies<input type="text" name="allergies" value="${escapeHtml(child.context.allergies||'')}" /></label>
             <label>Antécédents<input type="text" name="history" value="${escapeHtml(child.context.history||'')}" /></label>
@@ -2963,11 +2948,7 @@ try {
           try {
           const fd = new FormData(f);
           const id = fd.get('id').toString();
-          let photoDataUrl = child?.photo || null;
-          const file = fd.get('photo');
-          if (file instanceof File && file.size > 0) {
-            try { photoDataUrl = await fileToDataUrl(file); } catch {}
-          }
+          const photoUrl = child?.photo || null;
           const firstName = fd.get('firstName').toString().trim();
           const sex = fd.get('sex').toString();
           const newDob = fd.get('dob').toString();
@@ -2982,7 +2963,7 @@ try {
             first_name: firstName,
             sex,
             dob: newDob,
-            photo_url: photoDataUrl,
+            photo_url: photoUrl,
             milestones,
             context_allergies: fd.get('allergies').toString(),
             context_history: fd.get('history').toString(),
@@ -3071,7 +3052,7 @@ try {
           const childrenAll = store.get(K.children, []);
           const c = childrenAll.find(x=>x.id===id);
           if (!c) return;
-          c.firstName = firstName; c.sex = sex; c.dob = newDob; c.photo = photoDataUrl;
+          c.firstName = firstName; c.sex = sex; c.dob = newDob; c.photo = photoUrl;
           c.context = {
             allergies: payload.context_allergies,
             history: payload.context_history,

--- a/index.html
+++ b/index.html
@@ -270,8 +270,6 @@
           <label>Taille (cm)<input type="number" step="0.1" name="height" /></label>
           <label>Poids (kg)<input type="number" step="0.01" name="weight" /></label>
           <label>Dents (nb)<input type="number" step="1" name="teeth" /></label>
-          <label>Photo/avatar<input type="file" name="photo" accept="image/*" /></label>
-
           <h3>Contexte</h3>
           <label>Allergies<input type="text" name="allergies" placeholder="Arachides, pollen…" /></label>
           <label>Antécédents<input type="text" name="history" placeholder="Familiaux, médicaux…" /></label>


### PR DESCRIPTION
## Summary
- remove the photo/avatar field from the child onboarding form
- stop rendering a photo upload control when editing a child profile
- drop client-side handling of uploaded avatar files during child profile create/update flows

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c85b0d2f3083218bf2ab3d31e48450