### PR TITLE
Retirer la mention « connecté » dans les en-têtes statiques

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -25,7 +25,7 @@
       </nav>
       <div class="auth-actions">
         <button id="nav-toggle" class="nav-toggle" aria-controls="main-nav" aria-expanded="false" title="Menu">☰</button>
-        <span id="login-status" class="login-status" hidden>connecté</span>
+        <span id="login-status" class="login-status" hidden aria-label="Connecté" title="Connecté"></span>
         <button id="btn-login" class="btn btn-secondary">Se connecter</button>
         <button id="btn-logout" class="btn btn-secondary" hidden>Se déconnecter</button>
       </div>

--- a/la-theorie-de-l-attachement.html
+++ b/la-theorie-de-l-attachement.html
@@ -25,7 +25,7 @@
       </nav>
       <div class="auth-actions">
         <button id="nav-toggle" class="nav-toggle" aria-controls="main-nav" aria-expanded="false" title="Menu">☰</button>
-        <span id="login-status" class="login-status" hidden>connecté</span>
+        <span id="login-status" class="login-status" hidden aria-label="Connecté" title="Connecté"></span>
         <button id="btn-login" class="btn btn-secondary">Se connecter</button>
         <button id="btn-logout" class="btn btn-secondary" hidden>Se déconnecter</button>
       </div>

--- a/la-theorie-de-l-esprit.html
+++ b/la-theorie-de-l-esprit.html
@@ -25,7 +25,7 @@
       </nav>
       <div class="auth-actions">
         <button id="nav-toggle" class="nav-toggle" aria-controls="main-nav" aria-expanded="false" title="Menu">☰</button>
-        <span id="login-status" class="login-status" hidden>connecté</span>
+        <span id="login-status" class="login-status" hidden aria-label="Connecté" title="Connecté"></span>
         <button id="btn-login" class="btn btn-secondary">Se connecter</button>
         <button id="btn-logout" class="btn btn-secondary" hidden>Se déconnecter</button>
       </div>

--- a/les-1000-premiers-jours.html
+++ b/les-1000-premiers-jours.html
@@ -25,7 +25,7 @@
       </nav>
       <div class="auth-actions">
         <button id="nav-toggle" class="nav-toggle" aria-controls="main-nav" aria-expanded="false" title="Menu">☰</button>
-        <span id="login-status" class="login-status" hidden>connecté</span>
+        <span id="login-status" class="login-status" hidden aria-label="Connecté" title="Connecté"></span>
         <button id="btn-login" class="btn btn-secondary">Se connecter</button>
         <button id="btn-logout" class="btn btn-secondary" hidden>Se déconnecter</button>
       </div>

--- a/messages.html
+++ b/messages.html
@@ -51,7 +51,7 @@
       </nav>
       <div class="auth-actions">
         <button id="nav-toggle" class="nav-toggle" aria-controls="main-nav" aria-expanded="false" title="Menu">☰</button>
-        <span id="login-status" class="login-status" hidden>connecté</span>
+        <span id="login-status" class="login-status" hidden aria-label="Connecté" title="Connecté"></span>
         <button id="btn-login" class="btn btn-secondary">Se connecter</button>
         <button id="btn-logout" class="btn btn-secondary" hidden>Se déconnecter</button>
       </div>


### PR DESCRIPTION
## Summary
- retire la chaîne « connecté » toujours affichée dans les en-têtes des pages statiques
- aligne ces pages sur l’indicateur visuel seul avec libellés d’accessibilité

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8a6a7a8688321961ad6907e17bb5d