### PR TITLE
Afficher le code anonyme sans connexion automatique

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1309,18 +1309,19 @@ try {
       }
       const data = payload.profile;
       console.log('createAnonymousProfile -> profile:', data);
-      setActiveProfile({ ...data, isAnonymous: true });
+      // Ne pas connecter automatiquement l’utilisateur : on lui fournit le code et on le laisse se connecter manuellement.
+      setActiveProfile(null);
       authSession = null;
-      const current = store.get(K.user) || {};
-      const pseudo = data.full_name || '';
-      if (pseudo !== current.pseudo) {
-        store.set(K.user, { ...current, pseudo });
-      }
       if (status) {
         status.classList.remove('error');
-        status.textContent = `Voici ton code unique : ${data.code_unique}. Garde-le précieusement pour te reconnecter sur n’importe quel appareil.`;
+        status.innerHTML = `Ton code unique : <strong>${data.code_unique}</strong>.<br>Garde-le précieusement et saisis-le juste en dessous dans « Se connecter avec un code ».`;
       }
-      location.hash = '#/dashboard';
+      const inputCode = $('#anon-code-input');
+      if (inputCode) {
+        inputCode.value = data.code_unique || '';
+        inputCode.focus();
+        try { inputCode.select(); } catch {}
+      }
     } catch (e) {
       console.log('createAnonymousProfile exception:', e);
       console.error('createAnonymousProfile failed', e);


### PR DESCRIPTION
## Summary
- éviter la connexion automatique après la création d'un profil anonyme
- afficher immédiatement le code unique et les consignes sous le bouton de création
- préremplir le champ de connexion avec le code généré pour guider l'utilisateur

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c9457ce9708321aa5ecca9aab6f0ea