### PR TITLE
Redirect header login button to login options page

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1565,13 +1565,33 @@ try {
     }
   }
 
-  $('#btn-login').addEventListener('click', async (e) => {
+  function redirectToLogin() {
+    const targetHash = '#/login';
+    if (location.hash === targetHash) return;
+    if (location.hash.startsWith('#/')) {
+      location.hash = targetHash;
+      return;
+    }
+    const path = location.pathname || '';
+    if (path === '/' || path.endsWith('/') || path.endsWith('/index.html')) {
+      location.hash = targetHash;
+      return;
+    }
+    let basePath = path;
+    if (path.endsWith('.html')) {
+      basePath = path.replace(/[^/]*$/, '');
+    } else if (!path.endsWith('/')) {
+      basePath = `${path}/`;
+    }
+    if (!basePath.startsWith('/')) {
+      basePath = `/${basePath}`;
+    }
+    location.href = `${basePath}${targetHash}`;
+  }
+
+  $('#btn-login').addEventListener('click', (e) => {
     e.preventDefault();
-    const btn = e.currentTarget;
-    if (btn.dataset.busy === '1') return;
-    btn.dataset.busy = '1';
-    btn.disabled = true;
-    try { await signInGoogle(); } finally { /* redirect expected; keep disabled */ }
+    redirectToLogin();
   });
   // Buttons on /login and /signup pages (event delegation for robustness)
   document.addEventListener('click', (e) => {

--- a/assets/blog.js
+++ b/assets/blog.js
@@ -68,10 +68,32 @@ function setupHeader(){
   const navBtn = $('#nav-toggle');
   const mainNav = $('#main-nav');
   const navBackdrop = $('#nav-backdrop');
-  $('#btn-login')?.addEventListener('click', async e=>{
+  const redirectToLogin = () => {
+    const targetHash = '#/login';
+    if (location.hash === targetHash) return;
+    if (location.hash.startsWith('#/')) {
+      location.hash = targetHash;
+      return;
+    }
+    const path = location.pathname || '';
+    if (path === '/' || path.endsWith('/') || path.endsWith('/index.html')) {
+      location.hash = targetHash;
+      return;
+    }
+    let basePath = path;
+    if (path.endsWith('.html')) {
+      basePath = path.replace(/[^/]*$/, '');
+    } else if (!path.endsWith('/')) {
+      basePath = `${path}/`;
+    }
+    if (!basePath.startsWith('/')) {
+      basePath = `/${basePath}`;
+    }
+    location.href = `${basePath}${targetHash}`;
+  };
+  $('#btn-login')?.addEventListener('click', e=>{
     e.preventDefault();
-    const btn=e.currentTarget; if(btn.dataset.busy==='1') return; btn.dataset.busy='1'; btn.disabled=true;
-    try{ await signInGoogle(); } finally{}
+    redirectToLogin();
   });
   $('#btn-logout')?.addEventListener('click', async e=>{
     const btn=e.currentTarget; if(btn.dataset.busy==='1') return; btn.dataset.busy='1'; btn.disabled=true;

--- a/assets/messages.js
+++ b/assets/messages.js
@@ -48,6 +48,33 @@ function updateHeaderAuth(){
 }
 
 function setupHeader(){
+  const redirectToLogin = () => {
+    const targetHash = '#/login';
+    if (location.hash === targetHash) return;
+    if (location.hash.startsWith('#/')) {
+      location.hash = targetHash;
+      return;
+    }
+    const path = location.pathname || '';
+    if (path === '/' || path.endsWith('/') || path.endsWith('/index.html')) {
+      location.hash = targetHash;
+      return;
+    }
+    let basePath = path;
+    if (path.endsWith('.html')) {
+      basePath = path.replace(/[^/]*$/, '');
+    } else if (!path.endsWith('/')) {
+      basePath = `${path}/`;
+    }
+    if (!basePath.startsWith('/')) {
+      basePath = `/${basePath}`;
+    }
+    location.href = `${basePath}${targetHash}`;
+  };
+  $('#btn-login')?.addEventListener('click', e=>{
+    e.preventDefault();
+    redirectToLogin();
+  });
   $('#btn-logout')?.addEventListener('click', async e=>{
     const btn = e.currentTarget; if(btn.dataset.busy==='1') return; btn.dataset.busy='1'; btn.disabled=true;
     try{


### PR DESCRIPTION
## Summary
- redirect the header "Se connecter" button to the login options route instead of launching Google sign-in directly
- apply the same navigation helper on the SPA, blog, and messages pages so static pages also jump to the login screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9810b5c888321b178a2bf722d938f