### PR TITLE
Fix anonymous notification support

### DIFF
--- a/lib/anon-community.js
+++ b/lib/anon-community.js
@@ -48,6 +48,23 @@ function buildInFilter(values) {
   return `in.(${safeValues.join(',')})`;
 }
 
+function sanitizeSince(raw, fallbackDays = null) {
+  if (raw != null) {
+    const str = String(raw).trim();
+    if (str) {
+      const time = Date.parse(str);
+      if (!Number.isNaN(time)) {
+        return new Date(time).toISOString();
+      }
+    }
+  }
+  if (fallbackDays != null) {
+    const ms = Date.now() - Math.max(0, Number(fallbackDays) || 0) * 24 * 3600 * 1000;
+    return new Date(ms).toISOString();
+  }
+  return null;
+}
+
 export async function processAnonCommunityRequest(body) {
   try {
     const action = String(body?.action || '').trim();
@@ -178,6 +195,86 @@ export async function processAnonCommunityRequest(body) {
         { method: 'DELETE', headers }
       );
       return { status: 200, body: { success: true } };
+    }
+
+    if (action === 'recent-replies') {
+      const sinceIso = sanitizeSince(body?.since, 7);
+      const ownParams = new URLSearchParams({ select: 'id', limit: '200' });
+      ownParams.append('user_id', `eq.${profileId}`);
+      const owned = await supabaseRequest(
+        `${supaUrl}/rest/v1/forum_topics?${ownParams.toString()}`,
+        { headers }
+      );
+      const myTopics = Array.isArray(owned) ? owned : [];
+      const repliedParams = new URLSearchParams({ select: 'topic_id', limit: '500' });
+      repliedParams.append('user_id', `eq.${profileId}`);
+      const replied = await supabaseRequest(
+        `${supaUrl}/rest/v1/forum_replies?${repliedParams.toString()}`,
+        { headers }
+      );
+      const myReplies = Array.isArray(replied) ? replied : [];
+      const topicIdSet = new Set();
+      myTopics.forEach((t) => { if (t?.id != null) topicIdSet.add(String(t.id)); });
+      myReplies.forEach((r) => { if (r?.topic_id != null) topicIdSet.add(String(r.topic_id)); });
+      if (!topicIdSet.size) {
+        return { status: 200, body: { replies: [], authors: {}, topics: {} } };
+      }
+      const repliesParams = new URLSearchParams({
+        select: 'id,topic_id,user_id,created_at',
+        order: 'created_at.asc',
+        limit: '100',
+      });
+      const inFilter = buildInFilter(topicIdSet);
+      if (inFilter) repliesParams.append('topic_id', inFilter);
+      repliesParams.append('user_id', `neq.${profileId}`);
+      if (sinceIso) repliesParams.append('created_at', `gt.${sinceIso}`);
+      const repliesData = await supabaseRequest(
+        `${supaUrl}/rest/v1/forum_replies?${repliesParams.toString()}`,
+        { headers }
+      );
+      const replies = Array.isArray(repliesData)
+        ? repliesData.map((r) => ({
+            ...r,
+            topic_id: r?.topic_id != null ? String(r.topic_id) : r?.topic_id,
+            user_id: r?.user_id != null ? String(r.user_id) : r?.user_id,
+          }))
+        : [];
+      if (!replies.length) {
+        return { status: 200, body: { replies: [], authors: {}, topics: {} } };
+      }
+      const authorIds = Array.from(new Set(replies.map((r) => r.user_id).filter(Boolean)));
+      const authors = {};
+      if (authorIds.length) {
+        const authorFilter = buildInFilter(authorIds);
+        if (authorFilter) {
+          const authorParams = new URLSearchParams({ select: 'id,full_name' });
+          authorParams.append('id', authorFilter);
+          const authorRows = await supabaseRequest(
+            `${supaUrl}/rest/v1/profiles?${authorParams.toString()}`,
+            { headers }
+          );
+          (Array.isArray(authorRows) ? authorRows : []).forEach((p) => {
+            if (p?.id != null) authors[String(p.id)] = p.full_name || '';
+          });
+        }
+      }
+      const replyTopicIds = new Set(replies.map((r) => r.topic_id).filter(Boolean));
+      const topicsMap = {};
+      if (replyTopicIds.size) {
+        const topicFilter = buildInFilter(replyTopicIds);
+        if (topicFilter) {
+          const topicParams = new URLSearchParams({ select: 'id,title' });
+          topicParams.append('id', topicFilter);
+          const topicRows = await supabaseRequest(
+            `${supaUrl}/rest/v1/forum_topics?${topicParams.toString()}`,
+            { headers }
+          );
+          (Array.isArray(topicRows) ? topicRows : []).forEach((t) => {
+            if (t?.id != null) topicsMap[String(t.id)] = t.title || '';
+          });
+        }
+      }
+      return { status: 200, body: { replies, authors, topics: topicsMap } };
     }
 
     throw new HttpError(400, 'Unknown action');

--- a/lib/anon-messages.js
+++ b/lib/anon-messages.js
@@ -27,6 +27,23 @@ function buildInFilter(values) {
   return `in.(${safe.join(',')})`;
 }
 
+function sanitizeSince(raw, fallbackDays = null) {
+  if (raw != null) {
+    const str = String(raw).trim();
+    if (str) {
+      const time = Date.parse(str);
+      if (!Number.isNaN(time)) {
+        return new Date(time).toISOString();
+      }
+    }
+  }
+  if (fallbackDays != null) {
+    const ms = Date.now() - Math.max(0, Number(fallbackDays) || 0) * 24 * 3600 * 1000;
+    return new Date(ms).toISOString();
+  }
+  return null;
+}
+
 function mapMessage(row) {
   if (!row || typeof row !== 'object') return null;
   return {
@@ -112,6 +129,39 @@ export async function processAnonMessagesRequest(body) {
           profiles: profilesList,
         },
       };
+    }
+
+    if (action === 'recent-activity') {
+      const sinceIso = sanitizeSince(body?.since, 7);
+      const params = new URLSearchParams({
+        select: 'id,sender_id,receiver_id,created_at',
+        order: 'created_at.asc',
+        limit: '50',
+      });
+      params.append('receiver_id', `eq.${profileId}`);
+      if (sinceIso) params.append('created_at', `gt.${sinceIso}`);
+      const rows = await supabaseRequest(
+        `${supaUrl}/rest/v1/messages?${params.toString()}`,
+        { headers }
+      );
+      const messages = Array.isArray(rows) ? rows.map(mapMessage).filter(Boolean) : [];
+      const senderIds = Array.from(new Set(messages.map((m) => m?.sender_id).filter(Boolean)));
+      const senders = {};
+      if (senderIds.length) {
+        const filter = buildInFilter(senderIds);
+        if (filter) {
+          const profParams = new URLSearchParams({ select: 'id,full_name' });
+          profParams.append('id', filter);
+          const profRows = await supabaseRequest(
+            `${supaUrl}/rest/v1/profiles?${profParams.toString()}`,
+            { headers }
+          );
+          (Array.isArray(profRows) ? profRows : []).forEach((p) => {
+            if (p?.id != null) senders[String(p.id)] = p.full_name || '';
+          });
+        }
+      }
+      return { status: 200, body: { messages, senders } };
     }
 
     if (action === 'get-conversation') {


### PR DESCRIPTION
## Summary
- add backend helpers so anonymous sessions can retrieve recent messages and community replies for notifications
- poll anonymous notifications in the SPA and wire the initialization flow to start/stop anonymous polling with profile changes
- align the messages interface with the shared notification store, adding anonymous polling and acknowledgement handling

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c989517af08321b36636bda1267611