### PR TITLE
Align history subtitle styling with dashboard overview

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2521,7 +2521,7 @@ try {
       hist.innerHTML = `
         <div class="card-header history-header">
           <h3>Historique de l’évolution</h3>
-          <p class="muted">Suivez en un coup d’œil les derniers ajouts et observations.</p>
+          <p class="page-subtitle">Suivez en un coup d’œil les derniers ajouts et observations.</p>
         </div>
       ` + (
         updates.length


### PR DESCRIPTION
## Summary
- update the history card subtitle to reuse the `page-subtitle` styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc8b4723c88321b8246cf7d05ef6a6