### PR TITLE
Harmonize history header subtitle color

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -913,7 +913,7 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
 .history-header p{
   margin:0;
   font-size:13px;
-  color:rgba(20,32,73,.65);
+  color:var(--muted);
 }
 .timeline{
   --timeline-gap:18px;


### PR DESCRIPTION
## Summary
- update the history card subtitle styling to reuse the shared muted color token

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc8cc7b82083218fbe43cb73c85f94