### PR TITLE
Adapte le fond des cartes d'évolution

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -939,18 +939,20 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
   grid-template-columns:24px 1fr;
   gap:16px;
   padding:18px 20px;
-  background:linear-gradient(135deg, rgba(18,29,66,.78), rgba(33,21,53,.72));
-  border:1px solid rgba(148,172,255,.28);
+  background:linear-gradient(135deg, rgba(10,14,20,.68), rgba(10,14,20,.52));
+  border:1px solid var(--border);
   border-radius:20px;
-  box-shadow:0 12px 28px rgba(5,10,25,.45);
-  backdrop-filter:blur(16px);
-  transition:transform .18s ease, box-shadow .24s ease, border-color .24s ease;
+  box-shadow:0 20px 50px rgba(0,0,0,.45);
+  backdrop-filter:blur(14px);
+  -webkit-backdrop-filter:blur(14px);
+  transition:transform .18s ease, box-shadow .24s ease, border-color .24s ease, background .24s ease;
   color:#f4f6ff;
 }
 .timeline-item:hover{
   transform:translateY(-2px);
-  box-shadow:0 18px 40px rgba(6,14,38,.52);
-  border-color:rgba(176,194,255,.45);
+  box-shadow:0 24px 56px rgba(0,0,0,.55);
+  border-color:rgba(255,255,255,.22);
+  background:linear-gradient(135deg, rgba(10,14,20,.76), rgba(10,14,20,.6));
 }
 .timeline-marker{
   position:relative;


### PR DESCRIPTION
## Summary
- applique un fond noir translucide sur les items de l'historique des évolutions
- harmonise l'ombre, la bordure et le blur pour se rapprocher du rendu du héros de la page d'accueil

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc8f8606808321ac3b1343191a24fe