### PR TITLE
Use OpenAI only for image generation

### DIFF
--- a/api/generate-image.js
+++ b/api/generate-image.js
@@ -1,10 +1,6 @@
 // Fonction serverless : /api/generate-image
-// Génère une illustration à partir d'un prompt. Tente d'abord Gemini (si clé fournie),
-// puis bascule sur OpenAI Images en secours si disponible.
+// Génère une illustration à partir d'un prompt via l'API Images d'OpenAI.
 export async function generateImage(body = {}) {
-  const googleKey = process.env.GOOGLE_API_KEY
-    || process.env.GOOGLE_GENERATIVE_AI_API_KEY
-    || process.env.GEMINI_API_KEY;
   const openaiKey = process.env.OPENAI_API_KEY;
 
   const promptRaw = (body?.prompt ?? '').toString().trim();
@@ -18,47 +14,13 @@ export async function generateImage(body = {}) {
   const child = safeChildSummary(body.child);
   const contextText = buildContextText(child);
 
-  const errors = [];
-  if (googleKey) {
-    try {
-      return await generateWithGoogle({ prompt, contextText, apiKey: googleKey });
-    } catch (err) {
-      errors.push({ provider: 'google', error: err });
-    }
-  }
-
-  if (openaiKey) {
-    try {
-      return await generateWithOpenAI({ prompt, contextText, apiKey: openaiKey });
-    } catch (err) {
-      errors.push({ provider: 'openai', error: err });
-    }
-  }
-
-  if (!googleKey && !openaiKey) {
-    const err = new Error('Missing GOOGLE_API_KEY or OPENAI_API_KEY');
+  if (!openaiKey) {
+    const err = new Error('Missing OPENAI_API_KEY');
     err.status = 500;
     throw err;
   }
 
-  if (errors.length) {
-    const lastError = errors[errors.length - 1].error;
-    const status = Number.isInteger(lastError?.status)
-      ? lastError.status
-      : Number.isInteger(lastError?.statusCode)
-        ? lastError.statusCode
-        : 502;
-    const details = errors
-      .map(({ provider, error }) => `${provider}: ${String(error?.message || error)}`)
-      .join(' | ');
-    const err = new Error(details || 'Image generation failed');
-    err.status = status;
-    throw err;
-  }
-
-  const err = new Error('Image generation failed');
-  err.status = 500;
-  throw err;
+  return await generateWithOpenAI({ prompt, contextText, apiKey: openaiKey });
 }
 
 function buildContextText(child) {
@@ -66,64 +28,6 @@ function buildContextText(child) {
     return `Contexte enfant: ${JSON.stringify(child)}`;
   }
   return 'Contexte enfant: aucun détail spécifique.';
-}
-
-async function generateWithGoogle({ prompt, contextText, apiKey }) {
-  const parts = [
-    { text: 'Crée une illustration colorée, douce et rassurante adaptée aux enfants de 0 à 7 ans. Style chaleureux, sans violence ni éléments effrayants.' },
-    { text: contextText },
-    { text: `Description à illustrer: ${prompt}` }
-  ];
-
-  const payload = {
-    contents: [
-      {
-        role: 'user',
-        parts
-      }
-    ],
-    generationConfig: {
-      temperature: 0.5,
-      responseMimeType: 'image/png'
-    }
-  };
-
-  const endpoint = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image:generateContent';
-  const url = `${endpoint}?key=${encodeURIComponent(apiKey)}`;
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload)
-  });
-  const text = await resp.text();
-  if (!resp.ok) {
-    let details = text;
-    try {
-      const errJson = JSON.parse(text);
-      details = errJson?.error?.message || errJson?.error?.status || details;
-    } catch {}
-    const err = new Error(`Gemini error: ${details}`);
-    err.status = resp.status >= 400 ? resp.status : 502;
-    throw err;
-  }
-
-  let data;
-  try { data = JSON.parse(text); }
-  catch {
-    const err = new Error('Invalid response from Gemini');
-    err.status = 502;
-    throw err;
-  }
-
-  const inlineData = data?.candidates?.[0]?.content?.parts?.find(part => part?.inlineData?.data)?.inlineData;
-  if (!inlineData?.data) {
-    const err = new Error('No image data returned');
-    err.status = 502;
-    throw err;
-  }
-
-  const mimeType = inlineData.mimeType || 'image/png';
-  return { imageBase64: inlineData.data, mimeType };
 }
 
 async function generateWithOpenAI({ prompt, contextText, apiKey }) {


### PR DESCRIPTION
## Summary
- remove the Gemini fallback from the image generation endpoint
- require an OpenAI API key and delegate generation to the OpenAI Images API only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd1f3f89f083219d52f4787dc0257b