### PR TITLE
Expose image model information in generator

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url';
 import { processAnonChildrenRequest } from '../lib/anon-children.js';
 import { processAnonCommunityRequest } from '../lib/anon-community.js';
 import { processAnonMessagesRequest } from '../lib/anon-messages.js';
-import { generateImage as generateImageFromPrompt } from './generate-image.js';
+import { generateImage as generateImageFromPrompt, IMAGE_MODEL } from './generate-image.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -311,7 +311,9 @@ const server = createServer(async (req, res) => {
       return send(res, 200, JSON.stringify(out), { 'Content-Type': 'application/json; charset=utf-8' });
     } catch (e) {
       const status = Number.isInteger(e?.status) ? e.status : Number.isInteger(e?.statusCode) ? e.statusCode : 500;
-      return send(res, status, JSON.stringify({ error: 'Image generation failed', details: String(e?.message || e) }), { 'Content-Type': 'application/json; charset=utf-8' });
+      const details = e?.details ? String(e.details) : String(e?.message || e);
+      const payload = { error: 'Image generation failed', details, model: IMAGE_MODEL };
+      return send(res, status, JSON.stringify(payload), { 'Content-Type': 'application/json; charset=utf-8' });
     }
   }
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -2154,8 +2154,10 @@ try {
         }
         if (imgEmpty) imgEmpty.classList.add('hidden');
         if (sImage) {
-          sImage.textContent = 'Image générée !';
-          setTimeout(() => { if (sImage.textContent === 'Image générée !') sImage.textContent = ''; }, 4000);
+          const modelLabel = result.model ? ` via ${result.model}` : '';
+          const successMsg = `Image générée${modelLabel} !`;
+          sImage.textContent = successMsg;
+          setTimeout(() => { if (sImage.textContent === successMsg) sImage.textContent = ''; }, 4000);
         }
       } catch (err) {
         if (sImage) sImage.textContent = 'Génération impossible pour le moment.';
@@ -4321,7 +4323,13 @@ try {
     if (!res.ok) {
       try {
         const j = JSON.parse(raw);
-        throw new Error(j.error || j.details || raw || 'AI backend error');
+        const messageParts = [];
+        if (j.details) messageParts.push(j.details);
+        else if (j.error) messageParts.push(j.error);
+        else if (raw) messageParts.push(raw);
+        const modelNote = j.model ? ` (modèle: ${j.model})` : '';
+        const message = messageParts.length ? messageParts.join(' — ') : 'AI backend error';
+        throw new Error(`${message}${modelNote}`);
       } catch {
         throw new Error(raw || 'AI backend error');
       }
@@ -4330,7 +4338,7 @@ try {
     try { data = JSON.parse(raw); }
     catch { data = {}; }
     if (!data.imageBase64) throw new Error('Invalid image payload');
-    return { imageBase64: data.imageBase64, mimeType: data.mimeType || 'image/png' };
+    return { imageBase64: data.imageBase64, mimeType: data.mimeType || 'image/png', model: data.model };
   }
 
   // Animations révélées au scroll


### PR DESCRIPTION
## Summary
- expose the image model used by the generator via a shared constant with a default of `gpt-image-1`
- include the model name in success and error payloads for the image endpoint and propagate it to the SPA UI
- improve client-side error messaging so failures show the OpenAI details and model used

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cd2552186883219230418c94a93c3b