### PR TITLE
Fix OpenAI image generation configuration

### DIFF
--- a/api/openai-config.js
+++ b/api/openai-config.js
@@ -1,0 +1,34 @@
+const DEFAULT_BASE_URL = 'https://api.openai.com';
+
+function normalizeString(value) {
+  if (value == null) return '';
+  if (typeof value === 'string') return value.trim();
+  return String(value).trim();
+}
+
+function normalizeBaseUrl(value) {
+  const raw = normalizeString(value);
+  if (!raw) return DEFAULT_BASE_URL;
+  return raw.replace(/\/+$/, '') || DEFAULT_BASE_URL;
+}
+
+export function getOpenAIConfig(overrides = {}) {
+  const apiKey = normalizeString(overrides.apiKey ?? overrides.key ?? process.env.OPENAI_API_KEY ?? process.env.OPENAI_KEY);
+  const baseCandidate = overrides.baseUrl ?? overrides.baseURL ?? process.env.OPENAI_BASE_URL ?? process.env.OPENAI_API_BASE ?? DEFAULT_BASE_URL;
+  const baseUrl = normalizeBaseUrl(baseCandidate);
+  const organization = normalizeString(overrides.organization ?? overrides.org ?? process.env.OPENAI_ORGANIZATION ?? process.env.OPENAI_ORG_ID);
+  const project = normalizeString(overrides.project ?? process.env.OPENAI_PROJECT_ID ?? process.env.OPENAI_PROJECT);
+  return { apiKey, baseUrl, organization, project };
+}
+
+export function buildOpenAIHeaders(config, extraHeaders = {}) {
+  if (!config || !config.apiKey) {
+    throw new Error('Missing OpenAI API key');
+  }
+  const headers = { ...extraHeaders, Authorization: `Bearer ${config.apiKey}` };
+  const lowerKeys = Object.keys(headers).map((k) => k.toLowerCase());
+  if (!lowerKeys.includes('content-type')) headers['Content-Type'] = 'application/json';
+  if (config.organization) headers['OpenAI-Organization'] = config.organization;
+  if (config.project) headers['OpenAI-Project'] = config.project;
+  return headers;
+}


### PR DESCRIPTION
## Summary
- add a shared OpenAI configuration helper to normalise keys, base URL and headers for all serverless functions
- update the image generation endpoint to use the shared helper and always return CORS-compliant error payloads
- switch AI endpoints and the local dev server to the shared OpenAI configuration so all calls share the same behaviour

## Testing
- OPENAI_API_KEY=test npm start
- curl -s -X POST http://localhost:3000/api/generate-image -H 'Content-Type: application/json' -d '{"prompt":"test"}'


------
https://chatgpt.com/codex/tasks/task_e_68cd28abca508321b3a715a5a94b139f