### PR TITLE
Fix OpenAI base URL normalization

### DIFF
--- a/api/generate-image.js
+++ b/api/generate-image.js
@@ -99,7 +99,13 @@ function buildImagesEndpoint(config) {
 function normalizeBaseUrl(value) {
   const raw = typeof value === 'string' ? value.trim() : '';
   if (!raw) return 'https://api.openai.com';
-  return raw.replace(/\/+$/, '') || 'https://api.openai.com';
+  const trimmed = raw.replace(/\/+$/, '');
+  const lower = trimmed.toLowerCase();
+  if (lower.endsWith('/v1')) {
+    const withoutVersion = trimmed.slice(0, -3).replace(/\/+$/, '');
+    return withoutVersion || 'https://api.openai.com';
+  }
+  return trimmed || 'https://api.openai.com';
 }
 
 export default async function handler(req, res) {

--- a/api/openai-config.js
+++ b/api/openai-config.js
@@ -9,7 +9,15 @@ function normalizeString(value) {
 function normalizeBaseUrl(value) {
   const raw = normalizeString(value);
   if (!raw) return DEFAULT_BASE_URL;
-  return raw.replace(/\/+$/, '') || DEFAULT_BASE_URL;
+
+  const trimmed = raw.replace(/\/+$/, '');
+  const lower = trimmed.toLowerCase();
+  if (lower.endsWith('/v1')) {
+    const withoutVersion = trimmed.slice(0, -3).replace(/\/+$/, '');
+    return withoutVersion || DEFAULT_BASE_URL;
+  }
+
+  return trimmed || DEFAULT_BASE_URL;
 }
 
 export function getOpenAIConfig(overrides = {}) {


### PR DESCRIPTION
## Summary
- prevent duplicated `/v1` segments when the OpenAI base URL environment variable already contains the version suffix
- apply the same normalization in the image generation helper to ensure consistent endpoint building

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd372401c4832197215f6e547ecc5e