### PR TITLE
Improve OpenAI endpoint handling with shared URL helper

### DIFF
--- a/api/ai/[action].js
+++ b/api/ai/[action].js
@@ -2,6 +2,7 @@
 // Regroupe les anciens endpoints /api/ai/advice, /api/ai/recipes, /api/ai/story et /api/ai/comment
 
 import { buildOpenAIHeaders, getOpenAIConfig } from '../openai-config.js';
+import { buildOpenAIUrl } from '../openai-url.js';
 
 const ACTION_HANDLERS = {
   advice: handleAdvice,
@@ -74,7 +75,8 @@ Inclure: Sommeil, Alimentation, Repères de développement et Quand consulter.
 Prends en compte les champs du profil (allergies, type d’alimentation, style d’appétit, infos de sommeil, jalons, mesures) si présents.`;
   const user = `Contexte enfant: ${JSON.stringify(child)}\nQuestion du parent: ${question}`;
 
-  const response = await fetch(`${config.baseUrl}/v1/chat/completions`, {
+  const endpoint = buildOpenAIUrl(config.baseUrl, 'chat/completions', config.apiVersion);
+  const response = await fetch(endpoint, {
     method: 'POST',
     headers: buildOpenAIHeaders(config),
     body: JSON.stringify({
@@ -110,7 +112,8 @@ Prends en compte le type d’alimentation (allaitement/biberon/diversification),
 Structure la réponse avec: Idées de repas, Portions suggérées, Conseils pratiques, Liste de courses.`;
   const user = `Contexte enfant: ${JSON.stringify(child)}\nPréférences/contraintes: ${prefs}`;
 
-  const response = await fetch(`${config.baseUrl}/v1/chat/completions`, {
+  const endpoint = buildOpenAIUrl(config.baseUrl, 'chat/completions', config.apiVersion);
+  const response = await fetch(endpoint, {
     method: 'POST',
     headers: buildOpenAIHeaders(config),
     body: JSON.stringify({
@@ -145,7 +148,8 @@ Style ${sleepy ? 'très apaisant, vocabulaire doux, propice au coucher' : 'dynam
 Texte clair, phrases courtes. Termine par une petite morale positive.`;
   const user = `Contexte enfant: ${JSON.stringify(child)}\nThème souhaité: ${theme || 'libre'}`;
 
-  const response = await fetch(`${config.baseUrl}/v1/chat/completions`, {
+  const endpoint = buildOpenAIUrl(config.baseUrl, 'chat/completions', config.apiVersion);
+  const response = await fetch(endpoint, {
     method: 'POST',
     headers: buildOpenAIHeaders(config),
     body: JSON.stringify({
@@ -172,7 +176,8 @@ async function handleComment(body, config) {
   const content = String(body?.content || '').slice(0, 2000);
   const system = 'Tu es Ped’IA, un assistant bienveillant pour parents. Rédige un commentaire clair, positif et bref (moins de 50 mots) sur la mise à jour fournie.';
 
-  const response = await fetch(`${config.baseUrl}/v1/chat/completions`, {
+  const endpoint = buildOpenAIUrl(config.baseUrl, 'chat/completions', config.apiVersion);
+  const response = await fetch(endpoint, {
     method: 'POST',
     headers: buildOpenAIHeaders(config),
     body: JSON.stringify({

--- a/api/openai-url.js
+++ b/api/openai-url.js
@@ -1,0 +1,82 @@
+const DEFAULT_BASE_URL = 'https://api.openai.com';
+const VERSION_SUFFIX_REGEX = /\/v\d+[a-z0-9-]*$/i;
+const VERSION_PREFIX_REGEX = /^v\d+[a-z0-9-]*/i;
+
+function normalizeString(value) {
+  if (value == null) return '';
+  if (typeof value === 'string') return value.trim();
+  return String(value).trim();
+}
+
+export function resolveOpenAIBaseUrl(value, defaultBase = DEFAULT_BASE_URL) {
+  const raw = normalizeString(value);
+  if (!raw) {
+    return { baseUrl: defaultBase, version: undefined };
+  }
+
+  let trimmed = raw.replace(/\/+$/, '');
+  if (!trimmed) {
+    return { baseUrl: defaultBase, version: undefined };
+  }
+
+  let version;
+  while (VERSION_SUFFIX_REGEX.test(trimmed)) {
+    const match = trimmed.match(VERSION_SUFFIX_REGEX);
+    if (!match) break;
+    version = match[0].slice(1);
+    trimmed = trimmed.slice(0, -match[0].length).replace(/\/+$/, '');
+  }
+
+  const baseUrl = trimmed || defaultBase;
+  return { baseUrl, version };
+}
+
+export function normalizeOpenAIBaseUrl(value, defaultBase = DEFAULT_BASE_URL) {
+  return resolveOpenAIBaseUrl(value, defaultBase).baseUrl;
+}
+
+function normalizeVersion(defaultVersion) {
+  const raw = normalizeString(defaultVersion);
+  if (!raw) return 'v1';
+  const cleaned = raw.replace(/^\/+/, '').replace(/\/+$/, '');
+  return cleaned || 'v1';
+}
+
+export function normalizeOpenAIPath(path, defaultVersion = 'v1') {
+  const version = normalizeVersion(defaultVersion);
+  const defaultSegment = `/${version}`;
+  const raw = normalizeString(path);
+  if (!raw) return defaultSegment;
+
+  let withoutLeading = raw.replace(/^[\/]+/, '');
+  if (!withoutLeading) return defaultSegment;
+
+  withoutLeading = withoutLeading.replace(/\/{2,}/g, '/');
+
+  const versionMatch = withoutLeading.match(VERSION_PREFIX_REGEX);
+  if (versionMatch) {
+    const matched = versionMatch[0];
+    const rest = withoutLeading.slice(matched.length).replace(/^\/+/, '');
+    return rest ? `/${matched}/${rest}` : `/${matched}`;
+  }
+
+  const rest = withoutLeading.replace(/^\/+/, '');
+  const combined = rest ? `${defaultSegment}/${rest}` : defaultSegment;
+  return combined.replace(/\/{2,}/g, '/');
+}
+
+export function buildOpenAIUrl(baseUrl, path, defaultVersion = 'v1') {
+  const { baseUrl: cleanBase, version } = resolveOpenAIBaseUrl(baseUrl);
+  const normalizedPath = isVersionedOpenAIPath(path)
+    ? normalizeOpenAIPath(path)
+    : normalizeOpenAIPath(path, version || defaultVersion);
+  return `${cleanBase}${normalizedPath}`;
+}
+
+export function isVersionedOpenAIPath(path) {
+  const raw = normalizeString(path).replace(/^[\/]+/, '');
+  if (!raw) return false;
+  return VERSION_PREFIX_REGEX.test(raw);
+}
+
+export { DEFAULT_BASE_URL };

--- a/api/server.js
+++ b/api/server.js
@@ -10,6 +10,7 @@ import { processAnonChildrenRequest } from '../lib/anon-children.js';
 import { processAnonCommunityRequest } from '../lib/anon-community.js';
 import { processAnonMessagesRequest } from '../lib/anon-messages.js';
 import { buildOpenAIHeaders, getOpenAIConfig } from './openai-config.js';
+import { buildOpenAIUrl } from './openai-url.js';
 import { generateImage as generateImageFromPrompt, IMAGE_MODEL } from './generate-image.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -173,7 +174,8 @@ Prends en compte les champs du profil (allergies, type d’alimentation, style d
     { role:'user', content: user }
   ];
 
-  const res = await fetch(`${config.baseUrl}/v1/chat/completions`, {
+  const endpoint = buildOpenAIUrl(config.baseUrl, 'chat/completions', config.apiVersion);
+  const res = await fetch(endpoint, {
     method: 'POST',
     headers: buildOpenAIHeaders(config),
     body: JSON.stringify({ model: 'gpt-4o-mini', temperature: 0.4, messages: convo })
@@ -199,7 +201,8 @@ Donne des idées de menus et recettes adaptées à l’âge, en excluant les all
 Prends en compte le type d’alimentation (allaitement/biberon/diversification), le style d’appétit et, si pertinent, les repères de sommeil.
 Structure la réponse avec: Idées de repas, Portions suggérées, Conseils pratiques, Liste de courses.`;
   const user = `Contexte enfant: ${JSON.stringify(child)}\nPréférences/contraintes: ${prefs}`;
-  const r = await fetch(`${config.baseUrl}/v1/chat/completions`, {
+  const endpoint = buildOpenAIUrl(config.baseUrl, 'chat/completions', config.apiVersion);
+  const r = await fetch(endpoint, {
     method:'POST', headers: buildOpenAIHeaders(config),
     body: JSON.stringify({ model:'gpt-4o-mini', temperature:0.4, messages:[
       {role:'system', content: system}, {role:'user', content: user}
@@ -225,7 +228,8 @@ Rédige une histoire de ${duration} minute(s), adaptée à l’âge, avec le pr�
 Style ${sleepy ? 'très apaisant, vocabulaire doux, propice au coucher' : 'dynamique et bienveillant'}.
 Texte clair, phrases courtes. Termine par une petite morale positive.`;
   const user = `Contexte enfant: ${JSON.stringify(child)}\nThème souhaité: ${theme || 'libre'}`;
-  const r = await fetch(`${config.baseUrl}/v1/chat/completions`, {
+  const endpoint = buildOpenAIUrl(config.baseUrl, 'chat/completions', config.apiVersion);
+  const r = await fetch(endpoint, {
     method:'POST', headers: buildOpenAIHeaders(config),
     body: JSON.stringify({ model:'gpt-4o-mini', temperature:0.7, messages:[
       {role:'system', content: system}, {role:'user', content: user}
@@ -244,7 +248,8 @@ async function aiComment(body){
   const config = requireOpenAIConfig();
   const content = String(body.content || '').slice(0, 2000);
   const system = `Tu es Ped’IA, un assistant bienveillant pour parents. Rédige un commentaire clair, positif et bref (moins de 50 mots) sur la mise à jour fournie.`;
-  const r = await fetch(`${config.baseUrl}/v1/chat/completions`, {
+  const endpoint = buildOpenAIUrl(config.baseUrl, 'chat/completions', config.apiVersion);
+  const r = await fetch(endpoint, {
     method:'POST', headers: buildOpenAIHeaders(config),
     body: JSON.stringify({ model:'gpt-4o-mini', temperature:0.4, messages:[
       {role:'system', content: system}, {role:'user', content}


### PR DESCRIPTION
## Summary
- add a shared OpenAI URL helper that normalizes base URLs, detects existing version segments, and builds clean endpoints
- update the OpenAI config and image generator to surface apiVersion overrides and to use the shared helper for image requests
- switch the dynamic AI routes and local server text flows to rely on the shared helper for consistent chat completion endpoints

## Testing
- node - <<'NODE'
import { buildOpenAIUrl } from './api/openai-url.js';
const cases = [
  { base: undefined, path: 'chat/completions' },
  { base: 'https://api.openai.com', path: 'chat/completions' },
  { base: 'https://proxy.example.com/openai/v1', path: 'chat/completions' },
  { base: 'https://proxy.example.com/openai/v1beta', path: 'images/generations' },
  { base: 'https://proxy.example.com/openai', path: '/v1/chat/completions' },
  { base: 'https://proxy.example.com/openai/v1', path: '/v1/chat/completions' },
  { base: 'https://proxy.example.com/openai/v1beta', path: '/v1beta/chat/completions' },
  { base: 'https://proxy.example.com/openai/v1beta', path: 'v1beta/chat/completions' },
];
for (const c of cases) {
  console.log(c.base, '->', buildOpenAIUrl(c.base, c.path));
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cd3be86d0483218125d3eafc8d32ed