### PR TITLE
Support Azure-style OpenAI endpoints for image generation

### DIFF
--- a/api/generate-image.js
+++ b/api/generate-image.js
@@ -84,11 +84,13 @@ async function generateWithOpenAI({ prompt, contextText, config }) {
 function resolveConfig(overrides) {
   if (overrides && typeof overrides === 'object' && overrides.apiKey) {
     const baseUrl = overrides.baseUrl || overrides.baseURL;
-    const { baseUrl: normalizedBase, version } = resolveOpenAIBaseUrl(baseUrl);
+    const { baseUrl: normalizedBase, version, searchParams } = resolveOpenAIBaseUrl(baseUrl);
+    const queryString = searchParams?.toString() || '';
+    const rebuiltBase = queryString ? `${normalizedBase}?${queryString}` : normalizedBase;
     const versionOverride = overrides.apiVersion ?? overrides.version;
     return {
       ...overrides,
-      baseUrl: normalizedBase,
+      baseUrl: rebuiltBase,
       apiVersion: versionOverride ?? version ?? undefined,
     };
   }

--- a/api/openai-config.js
+++ b/api/openai-config.js
@@ -9,12 +9,14 @@ function normalizeString(value) {
 export function getOpenAIConfig(overrides = {}) {
   const apiKey = normalizeString(overrides.apiKey ?? overrides.key ?? process.env.OPENAI_API_KEY ?? process.env.OPENAI_KEY);
   const baseCandidate = overrides.baseUrl ?? overrides.baseURL ?? process.env.OPENAI_BASE_URL ?? process.env.OPENAI_API_BASE ?? DEFAULT_BASE_URL;
-  const { baseUrl, version: detectedVersion } = resolveOpenAIBaseUrl(baseCandidate, DEFAULT_BASE_URL);
+  const { baseUrl, version: detectedVersion, searchParams } = resolveOpenAIBaseUrl(baseCandidate, DEFAULT_BASE_URL);
+  const queryString = searchParams?.toString() || '';
+  const normalizedBase = queryString ? `${baseUrl}?${queryString}` : baseUrl;
   const organization = normalizeString(overrides.organization ?? overrides.org ?? process.env.OPENAI_ORGANIZATION ?? process.env.OPENAI_ORG_ID);
   const project = normalizeString(overrides.project ?? process.env.OPENAI_PROJECT_ID ?? process.env.OPENAI_PROJECT);
   const versionOverride = normalizeString(overrides.version ?? overrides.apiVersion ?? process.env.OPENAI_API_VERSION ?? '');
   const apiVersion = versionOverride || detectedVersion || undefined;
-  return { apiKey, baseUrl, organization, project, apiVersion };
+  return { apiKey, baseUrl: normalizedBase, organization, project, apiVersion };
 }
 
 export function buildOpenAIHeaders(config, extraHeaders = {}) {


### PR DESCRIPTION
## Summary
- preserve any query parameters when normalizing OpenAI base URLs
- detect Azure OpenAI endpoints and build image/chat URLs with api-version query strings instead of path segments
- keep query parameters when loading overrides so Azure deployments continue to work with the image generator

## Testing
- `node - <<'NODE'
import { buildOpenAIUrl } from './api/openai-url.js';
const cases = [
  ['https://api.openai.com', 'chat/completions', undefined],
  ['https://api.openai.com/v1', 'chat/completions', undefined],
  ['https://example.openai.azure.com/openai/deployments/mydeploy?api-version=2024-05-01-preview', 'chat/completions', undefined],
  ['https://example.openai.azure.com/openai/deployments/mydeploy', 'chat/completions', '2024-05-01-preview'],
  ['https://example.openai.azure.com/openai/deployments/mydeploy?foo=bar', 'chat/completions', '2024-05-01-preview'],
];
for (const [base, path, version] of cases) {
  console.log(base, '->', buildOpenAIUrl(base, path, version));
}
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68cd3f9da37483219ccfec4c6fa568e3