### PR TITLE
Améliore le feedback du générateur d'images

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2140,35 +2140,29 @@ try {
       }
       fImage.dataset.busy = '1';
       const submitBtn = fImage.querySelector('button[type="submit"],input[type="submit"]'); if (submitBtn) submitBtn.disabled = true;
-      if (sImage) sImage.textContent = 'Génération en cours…';
+      if (sImage) sImage.textContent = 'La génération peut prendre une à deux minutes. Merci de votre patience 🙏';
       if (imgPreview) { imgPreview.hidden = true; imgPreview.removeAttribute('src'); }
       if (imgEmpty) imgEmpty.classList.remove('hidden');
       try {
         const result = await askAIImage(prompt, currentChild);
         const src = result.imageUrl || '';
+        if (!src) {
+          throw new Error('EMPTY_IMAGE_URL');
+        }
         if (imgPreview) {
           imgPreview.src = src;
           imgPreview.alt = `Illustration générée pour : ${prompt}`;
-          imgPreview.hidden = !src;
+          imgPreview.hidden = false;
         }
         if (imgEmpty) imgEmpty.classList.add('hidden');
         if (sImage) {
-          const modelLabel = result.model ? ` via ${result.model}` : '';
-          const successMsg = `Image générée${modelLabel} !`;
-          sImage.textContent = successMsg;
-          setTimeout(() => { if (sImage.textContent === successMsg) sImage.textContent = ''; }, 4000);
+          sImage.textContent = '';
         }
       } catch (err) {
         console.error('Image generation failed', err);
+        if (imgEmpty) imgEmpty.classList.remove('hidden');
         if (sImage) {
-          const rawMsg = typeof err?.message === 'string' ? err.message : '';
-          let friendly = 'Génération impossible pour le moment.';
-          if (/missing openai/i.test(rawMsg)) {
-            friendly = 'Configuration serveur incomplète pour la génération d’images.';
-          } else if (/model/i.test(rawMsg) && /(not available|does not exist|no access)/i.test(rawMsg)) {
-            friendly = 'Modèle d’image indisponible pour cette clé API.';
-          }
-          sImage.textContent = friendly;
+          sImage.textContent = 'Génération impossible pour le moment. Réessayez plus tard.';
         }
       } finally {
         fImage.dataset.busy = '0';

--- a/index.html
+++ b/index.html
@@ -585,8 +585,8 @@
               </label>
               <div class="hstack">
                 <button class="btn btn-primary" type="submit">Générer</button>
-                <span id="ai-image-status" class="muted"></span>
               </div>
+              <p id="ai-image-status" class="muted"></p>
             </form>
             <div id="ai-image-output" class="card ai-image-output">
               <p id="ai-image-empty" class="muted">L’image générée s’affichera ici.</p>


### PR DESCRIPTION
## Summary
- afficher un message de patience pendant la génération d'image et le retirer après succès
- repositionner l'état du générateur d'images sous le bouton et harmoniser le message d'erreur
- sécuriser l'affichage en refusant les URLs d'image vides

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd5aba8c9c8321af4149322d10a1d1