### PR TITLE
Refactor image generation into Supabase-backed job queue

### DIFF
--- a/api/generate-image-status.js
+++ b/api/generate-image-status.js
@@ -1,0 +1,81 @@
+import { fetchImageJobById } from './image-job-store.js';
+
+function parseResult(raw) {
+  if (raw == null) return null;
+  if (typeof raw === 'object') return raw;
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed;
+  } catch {}
+  return trimmed;
+}
+
+export async function getImageJobStatus(jobId) {
+  if (!jobId) {
+    const err = new Error('jobId required');
+    err.status = 400;
+    throw err;
+  }
+  const job = await fetchImageJobById(jobId);
+  if (!job) {
+    const err = new Error('Job not found');
+    err.status = 404;
+    throw err;
+  }
+  const result = parseResult(job.result);
+  return {
+    status: job.status || 'pending',
+    result,
+    error_message: job.error_message ?? null,
+  };
+}
+
+function parseJobId(req) {
+  try {
+    const url = new URL(req.url || '', 'http://localhost');
+    const jobId = url.searchParams.get('jobId') || url.searchParams.get('jobid');
+    if (jobId && jobId.trim()) return jobId.trim();
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+
+  if (req.method === 'OPTIONS') {
+    return res.status(204).end();
+  }
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const jobId = parseJobId(req);
+    if (!jobId) {
+      return res.status(400).json({ error: 'jobId query parameter required' });
+    }
+    const status = await getImageJobStatus(jobId);
+    if (typeof status.result === 'object' && status.result !== null) {
+      const normalized = {};
+      if (typeof status.result.imageUrl === 'string') normalized.imageUrl = status.result.imageUrl;
+      if (typeof status.result.model === 'string') normalized.model = status.result.model;
+      status.result = normalized;
+    }
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    return res.status(200).send(JSON.stringify({ jobId, ...status }));
+  } catch (error) {
+    console.error('Failed to load image job status:', error);
+    const status = Number.isInteger(error?.status) ? error.status : 500;
+    const details = error?.details || error?.message || 'Status lookup failed';
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    return res.status(status).send(JSON.stringify({ error: 'Status lookup failed', details }));
+  }
+}

--- a/api/generate-image-worker.js
+++ b/api/generate-image-worker.js
@@ -1,0 +1,142 @@
+import { fetchPendingImageJobs, parseJobPayload, updateImageJob } from './image-job-store.js';
+import { generateImage, extractErrorDetails, resolveErrorModel, IMAGE_MODEL } from './generate-image.js';
+
+const DEFAULT_BATCH_LIMIT = 3;
+const MAX_ERROR_MESSAGE_LENGTH = 2000;
+
+function pickBatchLimit({ searchParams, body }) {
+  if (body && typeof body === 'object' && body !== null) {
+    const fromBody = Number(body.limit ?? body.batchSize);
+    if (Number.isFinite(fromBody) && fromBody > 0) {
+      return Math.min(Math.floor(fromBody), 10);
+    }
+  }
+  if (searchParams) {
+    const fromQuery = Number(searchParams.get('limit') ?? searchParams.get('batchSize'));
+    if (Number.isFinite(fromQuery) && fromQuery > 0) {
+      return Math.min(Math.floor(fromQuery), 10);
+    }
+  }
+  return DEFAULT_BATCH_LIMIT;
+}
+
+function normalizeResultPayload(result) {
+  if (!result || typeof result !== 'object') {
+    return {
+      imageUrl: typeof result === 'string' ? result : '',
+      model: IMAGE_MODEL,
+    };
+  }
+  return {
+    imageUrl: typeof result.imageUrl === 'string' ? result.imageUrl : '',
+    model: typeof result.model === 'string' && result.model ? result.model : IMAGE_MODEL,
+  };
+}
+
+function serializeResultPayload(result) {
+  const payload = normalizeResultPayload(result);
+  return JSON.stringify(payload);
+}
+
+function truncateErrorMessage(message) {
+  if (typeof message !== 'string') {
+    try {
+      return truncateErrorMessage(JSON.stringify(message));
+    } catch {
+      return 'Unknown error';
+    }
+  }
+  if (message.length <= MAX_ERROR_MESSAGE_LENGTH) return message;
+  return `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH - 3)}...`;
+}
+
+async function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    req.on('data', (chunk) => {
+      buf += chunk;
+      if (buf.length > 1e6) req.destroy();
+    });
+    req.on('end', () => resolve(buf));
+    req.on('error', reject);
+  });
+}
+
+export async function runImageGenerationWorker(options = {}) {
+  const { limit = DEFAULT_BATCH_LIMIT } = options;
+  const jobs = await fetchPendingImageJobs(limit);
+  const summaries = [];
+  for (const job of jobs) {
+    if (!job || !job.id) continue;
+    const payload = parseJobPayload(job.prompt);
+    const jobBody = {
+      prompt: payload.prompt,
+      child: payload.child,
+    };
+    try {
+      const result = await generateImage(jobBody);
+      const serializedResult = serializeResultPayload(result);
+      await updateImageJob(job.id, {
+        status: 'done',
+        result: serializedResult,
+        error_message: null,
+      }).catch((err) => {
+        console.error('Failed to update job as done:', err);
+      });
+      summaries.push({ id: job.id, status: 'done', model: result?.model ?? IMAGE_MODEL });
+    } catch (error) {
+      console.error(`Image generation failed for job ${job.id}:`, error);
+      const details = await extractErrorDetails(error);
+      const fallbackModel = resolveErrorModel(error);
+      const message = truncateErrorMessage(
+        typeof details === 'string' ? details : JSON.stringify(details)
+      );
+      await updateImageJob(job.id, {
+        status: 'failed',
+        result: null,
+        error_message: message,
+      }).catch((err) => {
+        console.error('Failed to mark job as failed:', err);
+      });
+      summaries.push({ id: job.id, status: 'failed', error: message, model: fallbackModel });
+    }
+  }
+  return { processed: summaries.length, jobs: summaries };
+}
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+
+  if (req.method === 'OPTIONS') {
+    return res.status(204).end();
+  }
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const url = new URL(req.url || '', 'http://localhost');
+    const raw = await readBody(req);
+    let body = {};
+    if (raw) {
+      try {
+        body = JSON.parse(raw);
+      } catch {
+        return res.status(400).json({ error: 'Invalid JSON body' });
+      }
+    }
+    const limit = pickBatchLimit({ searchParams: url.searchParams, body });
+    const summary = await runImageGenerationWorker({ limit });
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    return res.status(200).send(JSON.stringify({ ...summary, limit }));
+  } catch (error) {
+    console.error('Image worker execution failed:', error);
+    const status = Number.isInteger(error?.status) ? error.status : 500;
+    const message = error?.details || error?.message || 'Worker failure';
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    return res.status(status).send(JSON.stringify({ error: 'Image worker failed', details: message }));
+  }
+}

--- a/api/image-job-store.js
+++ b/api/image-job-store.js
@@ -1,0 +1,90 @@
+import { getServiceConfig, supabaseRequest } from '../lib/anon-children.js';
+
+function buildServiceHeaders(serviceKey) {
+  return {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+  };
+}
+
+function sanitizeLimit(limit, fallback = 5) {
+  const value = Number(limit);
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.min(Math.max(Math.floor(value), 1), 25);
+}
+
+export async function insertImageJob(record) {
+  const { supaUrl, serviceKey } = getServiceConfig();
+  const headers = {
+    ...buildServiceHeaders(serviceKey),
+    'Content-Type': 'application/json',
+    Prefer: 'return=representation',
+  };
+  const result = await supabaseRequest(`${supaUrl}/rest/v1/image_jobs`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(record),
+  });
+  if (Array.isArray(result)) {
+    return result[0] ?? null;
+  }
+  return result ?? null;
+}
+
+export async function fetchPendingImageJobs(limit = 5) {
+  const { supaUrl, serviceKey } = getServiceConfig();
+  const headers = buildServiceHeaders(serviceKey);
+  const safeLimit = sanitizeLimit(limit);
+  const url = `${supaUrl}/rest/v1/image_jobs?status=eq.pending&order=created_at.asc&limit=${safeLimit}`;
+  const rows = await supabaseRequest(url, { headers });
+  if (Array.isArray(rows)) return rows;
+  if (rows == null) return [];
+  return [rows];
+}
+
+export async function updateImageJob(id, patch) {
+  if (!id) throw new Error('Job id required');
+  const { supaUrl, serviceKey } = getServiceConfig();
+  const headers = {
+    ...buildServiceHeaders(serviceKey),
+    'Content-Type': 'application/json',
+    Prefer: 'return=minimal',
+  };
+  return supabaseRequest(`${supaUrl}/rest/v1/image_jobs?id=eq.${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers,
+    body: JSON.stringify(patch ?? {}),
+  });
+}
+
+export async function fetchImageJobById(id) {
+  if (!id) throw new Error('Job id required');
+  const { supaUrl, serviceKey } = getServiceConfig();
+  const headers = buildServiceHeaders(serviceKey);
+  const url = `${supaUrl}/rest/v1/image_jobs?id=eq.${encodeURIComponent(id)}&limit=1`;
+  const rows = await supabaseRequest(url, { headers });
+  if (Array.isArray(rows)) {
+    return rows[0] ?? null;
+  }
+  return rows ?? null;
+}
+
+export function parseJobPayload(rawPrompt) {
+  if (typeof rawPrompt !== 'string') {
+    return { prompt: '', child: null };
+  }
+  const trimmed = rawPrompt.trim();
+  if (!trimmed) return { prompt: '', child: null };
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed === 'object' && parsed !== null) {
+      const prompt = typeof parsed.prompt === 'string' ? parsed.prompt : trimmed;
+      const child = Object.prototype.hasOwnProperty.call(parsed, 'child') ? parsed.child : null;
+      return { prompt, child };
+    }
+    if (typeof parsed === 'string') {
+      return { prompt: parsed, child: null };
+    }
+  } catch {}
+  return { prompt: trimmed, child: null };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,10 @@
       "memory": 512,
       "maxDuration": 60
     },
+    "api/generate-image-worker.js": {
+      "memory": 512,
+      "maxDuration": 60
+    },
     "api/**/*.js": {
       "memory": 256,
       "maxDuration": 15


### PR DESCRIPTION
## Summary
- enqueue image generation requests into a Supabase-backed image_jobs table and return job ids from /api/generate-image
- add worker and status API routes to process pending jobs with OpenAI and expose job progress
- update the frontend flow to poll job status while showing a loader and surface worker errors, and expose the worker in the dev server and Vercel config

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd7d263c888321a9705881d4d5a06f