### PR TITLE
Refine AI child selector presentation

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2328,16 +2328,30 @@ try {
       const ageTxt = formatAge(child.dob);
       const selectedId = child.id;
       const opts = slim.map(c => `<option value="${c.id}" ${c.id===selectedId?'selected':''}>${escapeHtml(c.firstName)}${c.dob?` • ${formatAge(c.dob)}`:''}</option>`).join('');
+      box.className = 'card ai-child-selector';
+      const ctx = child.context || {};
+      const safeAge = ageTxt ? escapeHtml(ageTxt) : '';
+      const allergies = (ctx.allergies || '').trim();
+      const safeAllergies = allergies ? escapeHtml(allergies) : '';
+      const feeding = labelFeedingType(ctx.feedingType);
+      const safeFeeding = feeding && feeding !== '—' ? escapeHtml(feeding) : '';
+      const summaryParts = [];
+      if (safeAge) summaryParts.push(`Âge : ${safeAge}`);
+      if (safeAllergies) summaryParts.push(`Allergies : ${safeAllergies}`);
+      if (safeFeeding) summaryParts.push(`Alimentation : ${safeFeeding}`);
+      const summary = summaryParts.join(' • ');
+      const safeName = escapeHtml(child.firstName);
       box.innerHTML = `
-        <div class="hstack">
-          <strong>Profil IA:</strong>
-          <label style="margin-left:6px">Enfant
-            <select id="ai-child-switcher">${opts}</select>
+        <div class="ai-child-switcher">
+          <label for="ai-child-switcher">
+            <span class="ai-child-label">Enfant suivi</span>
+            <div class="ai-child-select">
+              <span class="ai-child-icon" aria-hidden="true">👶</span>
+              <select id="ai-child-switcher" aria-label="Sélectionner un enfant">${opts}</select>
+              <span class="ai-child-caret" aria-hidden="true">▾</span>
+            </div>
           </label>
-          <span class="chip">${escapeHtml(child.firstName)} • ${ageTxt}</span>
-          <span class="chip">Allergies: ${escapeHtml(child.context.allergies||'—')}</span>
-          <span class="chip">Alimentation: ${labelFeedingType(child.context.feedingType)}</span>
-          <span class="chip">Sommeil: ${summarizeSleep(child.context.sleep)}</span>
+          <p class="ai-child-hint">${summary ? `${safeName} • ${summary}` : safeName}</p>
         </div>`;
       const sel = box.querySelector('#ai-child-switcher');
       if (sel && !sel.dataset.bound) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1329,6 +1329,92 @@ section[data-route="/ai"] #ai-profile-indicator{
   box-shadow: none !important;
   background: transparent !important;
 }
+section[data-route="/ai"] #ai-profile-indicator.ai-child-selector{
+  border: none !important;
+  padding: 0;
+}
+section[data-route="/ai"] .ai-child-switcher{
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 20px;
+  border-radius: 22px;
+  border: 1px solid rgba(255,255,255,.18);
+  background: linear-gradient(135deg, rgba(255,225,200,.18), rgba(183,211,255,.16));
+  box-shadow: 0 24px 56px rgba(0,0,0,.45);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+section[data-route="/ai"] .ai-child-switcher label{
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  cursor: pointer;
+}
+section[data-route="/ai"] .ai-child-label{
+  font-size: 12px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,.72);
+  font-weight: 700;
+}
+section[data-route="/ai"] .ai-child-select{
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,.26);
+  background: rgba(0,0,0,.38);
+  box-shadow: 0 18px 42px rgba(0,0,0,.38);
+  transition: border-color .2s ease, box-shadow .2s ease, transform .2s ease;
+}
+section[data-route="/ai"] .ai-child-select:focus-within{
+  border-color: var(--orange-strong);
+  box-shadow: 0 24px 52px rgba(0,0,0,.48), 0 0 0 1px rgba(255,255,255,.05);
+  transform: translateY(-1px);
+}
+section[data-route="/ai"] .ai-child-icon{
+  font-size: 20px;
+}
+section[data-route="/ai"] .ai-child-select select{
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 600;
+  appearance: none;
+  padding: 0;
+  min-width: 0;
+}
+section[data-route="/ai"] .ai-child-select select:focus{
+  outline: none;
+}
+section[data-route="/ai"] .ai-child-select select option{
+  color: #000000;
+}
+section[data-route="/ai"] .ai-child-caret{
+  margin-left: auto;
+  font-size: 14px;
+  opacity: .66;
+  pointer-events: none;
+}
+section[data-route="/ai"] .ai-child-hint{
+  margin: 0;
+  font-size: 14px;
+  color: rgba(255,255,255,.76);
+}
+@media(max-width:600px){
+  section[data-route="/ai"] .ai-child-switcher{
+    padding: 16px;
+    border-radius: 18px;
+  }
+  section[data-route="/ai"] .ai-child-hint{
+    font-size: 13px;
+  }
+}
 /* Make only the “Créer un profil” link orange inside the indicator */
 section[data-route="/ai"] #ai-profile-indicator a[href*="/onboarding"]{
   color: var(--orange-strong) !important;


### PR DESCRIPTION
## Summary
- replace the AI profile indicator block with a focused child selector and summary hint
- restyle the selector with a dedicated glassmorphism card, custom icon, and focus states

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce5afc67b0832198cea1e400155058