### PR TITLE
Remove translucent card from AI child selector

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2328,7 +2328,7 @@ try {
       const ageTxt = formatAge(child.dob);
       const selectedId = child.id;
       const opts = slim.map(c => `<option value="${c.id}" ${c.id===selectedId?'selected':''}>${escapeHtml(c.firstName)}${c.dob?` • ${formatAge(c.dob)}`:''}</option>`).join('');
-      box.className = 'card ai-child-selector';
+      box.className = 'ai-child-selector';
       const ctx = child.context || {};
       const safeAge = ageTxt ? escapeHtml(ageTxt) : '';
       const allergies = (ctx.allergies || '').trim();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1337,13 +1337,12 @@ section[data-route="/ai"] .ai-child-switcher{
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 18px 20px;
-  border-radius: 22px;
-  border: 1px solid rgba(255,255,255,.18);
-  background: linear-gradient(135deg, rgba(255,225,200,.18), rgba(183,211,255,.16));
-  box-shadow: 0 24px 56px rgba(0,0,0,.45);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
+  padding: 0;
+  border: none;
+  background: none;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 section[data-route="/ai"] .ai-child-switcher label{
   display: flex;
@@ -1408,8 +1407,7 @@ section[data-route="/ai"] .ai-child-hint{
 }
 @media(max-width:600px){
   section[data-route="/ai"] .ai-child-switcher{
-    padding: 16px;
-    border-radius: 18px;
+    gap: 10px;
   }
   section[data-route="/ai"] .ai-child-hint{
     font-size: 13px;


### PR DESCRIPTION
## Summary
- remove the shared `card` styling from the AI child selector container
- simplify the child selector styling so only the selector and labels remain visible

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce5dd9332483218d0e5e6082d60421