### PR TITLE
Fix community topic backdrop interfering with bubbles

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1160,16 +1160,35 @@ section[data-route="/community"] .topic-pill{
 section[data-route="/community"] .topic-pill--empty{background:rgba(45,192,122,.12); border-color:rgba(45,192,122,.32); color:#8df0c2}
 section[data-route="/community"] .topic-actions .btn{padding:10px 14px; border-radius:14px}
 section[data-route="/community"] .topic-actions .topic-toggle{white-space:nowrap}
+/* Rebuild the frosted background without backdrop-filter so route canvases stay visible */
 section[data-route="/community"] .topic-body{
   display:grid;
   gap:18px;
   padding:20px;
   border-radius:22px;
-  background:rgba(7,11,19,.7);
+  position:relative;
+  isolation:isolate;
+  overflow:hidden;
+  background:linear-gradient(160deg, rgba(12,17,27,.88), rgba(6,9,15,.72));
   border:1px solid rgba(255,255,255,.12);
   box-shadow:inset 0 0 0 1px rgba(255,255,255,.04);
-  backdrop-filter:blur(18px) saturate(150%);
-  -webkit-backdrop-filter:blur(18px) saturate(150%);
+}
+section[data-route="/community"] .topic-body::before{
+  content:"";
+  position:absolute;
+  inset:-24%;
+  border-radius:inherit;
+  background:
+    radial-gradient(circle at 18% 8%, rgba(255,255,255,.18), transparent 58%),
+    radial-gradient(circle at 82% 0%, rgba(255,255,255,.12), transparent 60%),
+    linear-gradient(150deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+  opacity:.85;
+  pointer-events:none;
+  z-index:0;
+}
+section[data-route="/community"] .topic-body > *{
+  position:relative;
+  z-index:1;
 }
 section[data-route="/community"] .topic-content{font-size:15px; line-height:1.7; color:#f6f7ff; word-break:break-word}
 section[data-route="/community"] .topic-empty{


### PR DESCRIPTION
## Summary
- replace the community topic glass effect to avoid the backdrop-filter that dulled the route canvas bubbles
- layer gradient highlights and isolation on the topic body so particles remain visible while keeping the frosted appearance

## Testing
- not run (static change)


------
https://chatgpt.com/codex/tasks/task_e_68ce7ec988d4832191b00620e8f996ea