### PR TITLE
Ajuste le halo des cartes de discussion fermées

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1097,7 +1097,7 @@ section[data-route="/community"] .topic::before{
   height:240px;
   background:radial-gradient(ellipse at top, rgba(255,255,255,.18) 0%, rgba(255,255,255,0) 70%);
   opacity:.4;
-  transform:translateY(40%);
+  transform:translateY(68%);
   transition:opacity .35s ease, transform .35s ease;
   pointer-events:none;
   z-index:0;


### PR DESCRIPTION
## Summary
- ajuste la position du dégradé décoratif des cartes de discussion fermées pour supprimer la rupture de contraste visible en bas de carte

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce8a854d248321ba3ade38d9327390