### PR TITLE
Ajuster le contour des cartes de commentaires

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1194,8 +1194,7 @@ section[data-route="/community"] .topic-body{
   isolation:isolate;
   overflow:hidden;
   background:linear-gradient(160deg, rgba(12,17,27,.88), rgba(6,9,15,.72));
-  border:1px solid rgba(255,255,255,.12);
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,.04);
+  border:1px solid rgba(255,255,255,.14);
 }
 section[data-route="/community"] .topic-body::before{
   content:"";


### PR DESCRIPTION
## Summary
- adoucir le style des cartes de commentaires dans la communauté en supprimant l’effet de double contour

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ce8c8011e48321828f502bc46a1b83