### PR TITLE
Uniformise le fond des cartes de commentaires

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -939,20 +939,20 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
   grid-template-columns:24px 1fr;
   gap:16px;
   padding:18px 20px;
-  background:linear-gradient(135deg, rgba(10,14,20,.68), rgba(10,14,20,.52));
+  background:rgba(10,14,20,.64);
   border:1px solid var(--border);
   border-radius:20px;
   box-shadow:0 20px 50px rgba(0,0,0,.45);
   backdrop-filter:blur(14px);
   -webkit-backdrop-filter:blur(14px);
-  transition:transform .18s ease, box-shadow .24s ease, border-color .24s ease, background .24s ease;
+  transition:transform .18s ease, box-shadow .24s ease, border-color .24s ease, background-color .24s ease;
   color:#f4f6ff;
 }
 .timeline-item:hover{
   transform:translateY(-2px);
   box-shadow:0 24px 56px rgba(0,0,0,.55);
   border-color:rgba(255,255,255,.22);
-  background:linear-gradient(135deg, rgba(10,14,20,.76), rgba(10,14,20,.6));
+  background:rgba(10,14,20,.74);
 }
 .timeline-marker{
   position:relative;


### PR DESCRIPTION
## Summary
- remplace le dégradé des cartes de timeline par un fond noir translucide uniforme
- ajuste l'état au survol pour conserver un léger renforcement de l'opacité sans dégradé

## Testing
- non applicable

------
https://chatgpt.com/codex/tasks/task_e_68ce928311c48321b5a14b47708a8dda