### PR TITLE
Refactor FAQ section layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1637,133 +1637,212 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
 }
 .testimonial p{margin:0 0 8px; font-style:italic; font-size:15px; color:var(--text); opacity:.95}
 .testimonial .who{color:var(--muted); font-size:12px; font-weight:600}
-/* FAQ — mise en page immersive avec cartes vitrées */
+/* FAQ — module harmonisé */
 .faq-section{ position:relative; }
-.faq-modern{
-  position:relative; display:grid; gap:clamp(28px, 5vw, 48px);
-  padding:clamp(28px, 6vw, 56px);
-  border-radius:36px;
-  background:linear-gradient(135deg, rgba(255,232,214,.82), rgba(208,223,255,.78));
-  border:1px solid rgba(255,255,255,.45);
-  box-shadow:0 32px 80px rgba(27,39,63,.14);
-  overflow:hidden; isolation:isolate;
+.faq-wrapper{
+  position:relative;
+  display:grid;
+  gap:clamp(32px, 5vw, 56px);
+  grid-template-columns:minmax(0, .95fr) minmax(0, 1.05fr);
+  padding:clamp(32px, 7vw, 60px);
+  border-radius:40px;
+  background:linear-gradient(135deg, rgba(255,234,217,.88), rgba(210,222,255,.78));
+  border:1px solid rgba(255,255,255,.55);
+  box-shadow:0 36px 88px rgba(22,34,58,.16);
+  overflow:hidden;
+  isolation:isolate;
 }
-.faq-modern::before,
-.faq-modern::after{
-  content:""; position:absolute; border-radius:999px; opacity:.55; pointer-events:none;
+.faq-wrapper::before,
+.faq-wrapper::after{
+  content:""; position:absolute; border-radius:999px; pointer-events:none; filter:blur(0px);
 }
-.faq-modern::before{
-  width:360px; height:360px; top:-160px; right:-120px;
-  background:radial-gradient(circle at center, rgba(255,166,105,.6), rgba(255,166,105,0) 68%);
+.faq-wrapper::before{
+  width:420px; height:420px; top:-180px; right:-160px;
+  background:radial-gradient(circle at center, rgba(255,166,105,.55), rgba(255,166,105,0) 70%);
+  opacity:.6;
 }
-.faq-modern::after{
-  width:420px; height:420px; bottom:-180px; left:-140px;
-  background:radial-gradient(circle at center, rgba(123,154,255,.55), rgba(123,154,255,0) 70%);
+.faq-wrapper::after{
+  width:460px; height:460px; bottom:-220px; left:-180px;
+  background:radial-gradient(circle at center, rgba(122,158,255,.5), rgba(122,158,255,0) 68%);
+  opacity:.55;
 }
-.faq-modern-header{
-  position:relative; display:grid; gap:12px; max-width:560px; z-index:1;
+.faq-intro{
+  position:relative;
+  z-index:1;
+  display:grid;
+  gap:clamp(14px, 1.8vw, 20px);
+  align-content:flex-start;
 }
-.faq-modern-intro{
-  margin:0; font-size:16px; line-height:1.6; color:rgba(32,38,55,.82);
+.faq-eyebrow{
+  margin:0;
+  font-size:13px;
+  font-weight:700;
+  letter-spacing:.24em;
+  text-transform:uppercase;
+  color:var(--orange-strong);
 }
-.faq-tag-list{
-  display:flex; flex-wrap:wrap; gap:8px; margin-top:4px;
+.faq-intro-text{
+  margin:0;
+  font-size:15px;
+  line-height:1.7;
+  color:rgba(30,36,52,.82);
 }
-.faq-tag{
-  display:inline-flex; align-items:center; gap:6px; padding:6px 16px;
-  border-radius:999px; background:rgba(255,255,255,.55);
-  color:rgba(32,38,55,.8); font-size:13px; font-weight:600; letter-spacing:.2px;
-  box-shadow:inset 0 1px 0 rgba(255,255,255,.6);
+.faq-highlights{
+  margin:0;
+  padding:0;
+  list-style:none;
+  display:grid;
+  gap:10px;
+  color:rgba(30,36,52,.85);
+  font-size:14.5px;
 }
-.faq-modern-grid{
-  position:relative; z-index:1; display:grid;
-  gap:clamp(18px, 2vw, 24px);
-  grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));
+.faq-highlights li{
+  display:flex;
+  align-items:flex-start;
+  gap:10px;
+  padding:10px 16px;
+  border-radius:18px;
+  background:rgba(255,255,255,.58);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.68);
 }
-.faq-card{
-  position:relative; background:rgba(255,255,255,.9);
-  border-radius:24px; border:1px solid rgba(255,255,255,.75);
-  padding:20px 22px;
-  box-shadow:0 16px 40px rgba(21,30,63,.12);
-  transition:transform .25s ease, box-shadow .3s ease, border-color .3s ease, background .3s ease;
-  backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px);
-  --faq-tone-bg:rgba(66,84,245,.15);
-  --faq-tone-text:#4254f5;
-  --faq-tone-ring:rgba(66,84,245,.22);
+.faq-highlights span{ font-size:16px; line-height:1; }
+.faq-cta{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
 }
-.faq-card[data-tone="peach"]{ --faq-tone-bg:rgba(255,166,105,.2); --faq-tone-text:#f56a1c; --faq-tone-ring:rgba(255,166,105,.35); }
-.faq-card[data-tone="lavender"]{ --faq-tone-bg:rgba(183,161,255,.24); --faq-tone-text:#6a4cd9; --faq-tone-ring:rgba(183,161,255,.32); }
-.faq-card[data-tone="sea"]{ --faq-tone-bg:rgba(115,205,230,.22); --faq-tone-text:#0f93b9; --faq-tone-ring:rgba(115,205,230,.3); }
-.faq-card[data-tone="mint"]{ --faq-tone-bg:rgba(147,231,204,.26); --faq-tone-text:#0b8f6a; --faq-tone-ring:rgba(147,231,204,.32); }
-.faq-card[data-tone="berry"]{ --faq-tone-bg:rgba(233,166,255,.24); --faq-tone-text:#a328a4; --faq-tone-ring:rgba(233,166,255,.34); }
-.faq-card[data-tone="gold"]{ --faq-tone-bg:rgba(255,210,130,.26); --faq-tone-text:#a86c00; --faq-tone-ring:rgba(255,210,130,.38); }
-.faq-card:hover{
+.faq-cta .btn{ flex:0 0 auto; }
+.faq-items{
+  position:relative;
+  z-index:1;
+  display:grid;
+  gap:clamp(18px, 2vw, 22px);
+}
+.faq-item{
+  position:relative;
+  display:grid;
+  grid-template-columns:minmax(52px, auto) minmax(0, 1fr);
+  gap:18px;
+  padding:24px 26px;
+  border-radius:28px;
+  background:linear-gradient(140deg, rgba(255,255,255,.94), rgba(255,255,255,.78));
+  border:1px solid rgba(255,255,255,.62);
+  box-shadow:0 26px 66px rgba(21,33,58,.14);
+  transition:transform .22s ease, box-shadow .28s ease, border-color .28s ease;
+  --faq-tone-color:#4254f5;
+  --faq-tone-soft:rgba(66,84,245,.18);
+  --faq-tone-ring:rgba(66,84,245,.26);
+}
+.faq-item::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  background:linear-gradient(155deg, var(--faq-tone-soft), rgba(255,255,255,0));
+  opacity:.85;
+  pointer-events:none;
+}
+.faq-item:hover{
   transform:translateY(-4px);
-  box-shadow:0 22px 48px rgba(21,30,63,.16);
-  border-color:rgba(255,255,255,.9);
+  box-shadow:0 32px 82px rgba(21,33,58,.18);
+  border-color:rgba(255,255,255,.78);
 }
-.faq-card[open]{
-  background:rgba(255,255,255,.97);
-  box-shadow:0 26px 56px rgba(21,30,63,.18);
-  border-color:rgba(255,255,255,.95);
+.faq-item-icon{
+  position:relative;
+  width:56px;
+  height:56px;
+  border-radius:20px;
+  display:grid;
+  place-items:center;
+  font-size:24px;
+  background:rgba(255,255,255,.75);
+  color:var(--faq-tone-color);
+  box-shadow:0 16px 36px var(--faq-tone-ring);
+  z-index:1;
 }
-.faq-card summary{
-  margin:0; padding:0;
-  display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:16px;
-  list-style:none; cursor:pointer; font-weight:700; color:rgba(28,32,44,.95);
+.faq-item-body{
+  position:relative;
+  z-index:1;
+  display:grid;
+  gap:10px;
 }
-.faq-card summary::-webkit-details-marker{ display:none }
-.faq-card summary:focus-visible{
-  outline:3px solid rgba(66,84,245,.4);
-  outline-offset:6px; border-radius:18px;
+.faq-item-body h3{
+  margin:0;
+  font-size:clamp(17px, 2.2vw, 19px);
+  color:rgba(26,31,45,.96);
 }
-.faq-card-icon{
-  width:48px; height:48px; border-radius:18px;
-  display:grid; place-items:center; font-size:20px;
-  background:var(--faq-tone-bg);
-  color:var(--faq-tone-text);
-  box-shadow:0 12px 26px var(--faq-tone-ring);
+.faq-item-body p{
+  margin:0;
+  color:rgba(31,36,52,.85);
+  line-height:1.65;
+  font-size:15px;
 }
-.faq-card-question{
-  font-size:17px; line-height:1.4; letter-spacing:.1px;
+.faq-item-note{
+  font-style:italic;
+  color:rgba(26,31,45,.7);
 }
-.faq-card-chevron{
-  width:36px; height:36px; border-radius:50%;
-  display:inline-flex; align-items:center; justify-content:center;
-  background:rgba(66,84,245,.14);
-  color:var(--faq-tone-text);
-  font-size:18px; font-weight:700;
-  transition:transform .3s ease, background .3s ease, color .3s ease;
+.faq-item-list{
+  margin:0;
+  padding:0;
+  list-style:none;
+  display:grid;
+  gap:6px;
+  font-size:14.5px;
+  color:rgba(31,36,52,.82);
 }
-.faq-card-chevron::before{ content:"⌄"; transform:translateY(-2px); }
-.faq-card[open] .faq-card-chevron{
-  transform:rotate(180deg);
-  background:var(--faq-tone-text);
-  color:#fff;
+.faq-item-list li{
+  position:relative;
+  padding-left:18px;
 }
-.faq-answer{
-  display:grid; gap:8px;
-  margin:16px 0 0; padding-left:64px;
-  color:rgba(34,38,54,.9);
-  font-size:15px; line-height:1.65;
+.faq-item-list li::before{
+  content:"";
+  position:absolute;
+  left:0;
+  top:.6em;
+  width:8px;
+  height:8px;
+  border-radius:50%;
+  background:var(--faq-tone-color);
+  transform:translateY(-50%);
+  box-shadow:0 0 0 4px rgba(255,255,255,.8);
 }
-.faq-answer-highlight{
-  font-size:13px; font-weight:700; text-transform:uppercase;
-  letter-spacing:.12em; color:var(--faq-tone-text);
-  background:linear-gradient(90deg, rgba(255,255,255,.8), rgba(255,255,255,0));
-  padding:6px 12px; border-radius:999px;
-  justify-self:start;
+.faq-item-link{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  font-weight:600;
+  color:var(--faq-tone-color);
+  text-decoration:none;
 }
-.faq-card[open] .faq-answer-highlight{
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,.6);
+.faq-item-link::after{
+  content:"→";
+  transition:transform .2s ease;
 }
-@media(max-width:900px){
-  .faq-modern{ padding:clamp(24px, 8vw, 48px); }
+.faq-item-link:hover::after{ transform:translateX(3px); }
+.faq-item[data-tone="sun"]{ --faq-tone-color:#f56a1c; --faq-tone-soft:rgba(255,166,105,.28); --faq-tone-ring:rgba(255,166,105,.35); }
+.faq-item[data-tone="iris"]{ --faq-tone-color:#6a4cd9; --faq-tone-soft:rgba(183,161,255,.3); --faq-tone-ring:rgba(183,161,255,.36); }
+.faq-item[data-tone="lagoon"]{ --faq-tone-color:#0f93b9; --faq-tone-soft:rgba(115,205,230,.28); --faq-tone-ring:rgba(115,205,230,.34); }
+.faq-item[data-tone="mint"]{ --faq-tone-color:#0b8f6a; --faq-tone-soft:rgba(147,231,204,.32); --faq-tone-ring:rgba(147,231,204,.38); }
+.faq-item[data-tone="peony"]{ --faq-tone-color:#a328a4; --faq-tone-soft:rgba(233,166,255,.32); --faq-tone-ring:rgba(233,166,255,.38); }
+@media(max-width:1060px){
+  .faq-wrapper{ grid-template-columns:1fr; }
+  .faq-cta{ justify-content:flex-start; }
 }
-@media(max-width:640px){
-  .faq-modern-grid{ grid-template-columns:1fr; }
-  .faq-answer{ padding-left:0; }
-  .faq-card summary{ align-items:flex-start; }
+@media(max-width:720px){
+  .faq-wrapper{ padding:clamp(26px, 9vw, 40px); }
+  .faq-highlights li{ flex-wrap:nowrap; }
+  .faq-cta{ flex-direction:column; align-items:stretch; }
+  .faq-cta .btn{ width:100%; text-align:center; }
+}
+@media(max-width:560px){
+  .faq-item{
+    grid-template-columns:1fr;
+    text-align:left;
+  }
+  .faq-item-icon{
+    width:52px; height:52px;
+  }
+  .faq-item-list li{ padding-left:16px; }
 }
 
 /* Newsletter CTA (cohérent avec .cta-inner / testimonials / faq) */

--- a/index.html
+++ b/index.html
@@ -271,85 +271,69 @@
         </div>
 
         <div class="section bubble-mobile faq-section">
-          <div class="faq-modern">
-            <div class="faq-modern-header">
-              <h2 class="section-title">FAQ</h2>
-              <p class="section-subtitle">Vos questions les plus fréquentes.</p>
-              <p class="faq-modern-intro">Besoin d’un coup de main rapide&nbsp;? Explorez les points clés ci‑dessous ou écrivez‑nous pour un accompagnement personnalisé.</p>
-              <div class="faq-tag-list" aria-label="Thématiques de la FAQ">
-                <span class="faq-tag">Suivi quotidien</span>
-                <span class="faq-tag">Fonctionnalités IA</span>
-                <span class="faq-tag">Partage familial</span>
-                <span class="faq-tag">Confidentialité</span>
+          <div class="faq-wrapper">
+            <div class="faq-intro" aria-labelledby="faq-title">
+              <p class="faq-eyebrow">Besoin d’aide&nbsp;?</p>
+              <h2 id="faq-title" class="section-title">FAQ &amp; assistance</h2>
+              <p class="section-subtitle">Des réponses claires pour prendre en main Synap'Kids sereinement.</p>
+              <p class="faq-intro-text">Nous avons regroupé les questions les plus fréquentes autour du suivi, de l’IA et du partage familial. Si vous ne trouvez pas ce que vous cherchez, notre équipe est à un message de distance.</p>
+              <ul class="faq-highlights" aria-label="Points clés de l’assistance">
+                <li><span aria-hidden="true">✨</span> Guides pratiques et check-lists pas à pas</li>
+                <li><span aria-hidden="true">🛡️</span> Données protégées et synchronisation à votre rythme</li>
+                <li><span aria-hidden="true">🤝</span> Communauté et experts disponibles pour vous accompagner</li>
+              </ul>
+              <div class="faq-cta">
+                <a href="#/community" class="btn btn-primary">Rejoindre la communauté</a>
+                <a href="mailto:hello@synapkids.com" class="btn btn-secondary">Contacter l’équipe</a>
               </div>
             </div>
-            <div class="faq-modern-grid">
-              <details class="faq-card" data-tone="peach">
-                <summary>
-                  <span class="faq-card-icon" aria-hidden="true">📊</span>
-                  <span class="faq-card-question">Que puis‑je suivre avec Synap'Kids&nbsp;?</span>
-                  <span class="faq-card-chevron" aria-hidden="true"></span>
-                </summary>
-                <div class="faq-answer">
-                  <p>L'application permet de consigner croissance, sommeil, dents et jalons pour chaque enfant.</p>
-                  <span class="faq-answer-highlight">Astuce&nbsp;: activez les rappels mensuels pour garder votre suivi à jour.</span>
+            <div class="faq-items" aria-label="Questions fréquentes">
+              <article class="faq-item" data-tone="sun">
+                <div class="faq-item-icon" aria-hidden="true">📊</div>
+                <div class="faq-item-body">
+                  <h3>Comment suivre les progrès de mon enfant&nbsp;?</h3>
+                  <p>Créez un profil par enfant, ajoutez taille, poids, sommeil et jalons, puis retrouvez tout dans le dashboard illustré.</p>
+                  <ul class="faq-item-list">
+                    <li>Rappels personnalisés pour vos mesures mensuelles.</li>
+                    <li>Courbes basées sur les repères de l’OMS.</li>
+                  </ul>
                 </div>
-              </details>
-              <details class="faq-card" data-tone="lavender">
-                <summary>
-                  <span class="faq-card-icon" aria-hidden="true">🤖</span>
-                  <span class="faq-card-question">L'IA remplace‑t‑elle le pédiatre&nbsp;?</span>
-                  <span class="faq-card-chevron" aria-hidden="true"></span>
-                </summary>
-                <div class="faq-answer">
-                  <p>Non, elle fournit des conseils personnalisés mais ne substitue jamais un avis médical professionnel.</p>
-                  <span class="faq-answer-highlight">Consultez toujours un spécialiste en cas de doute ou de situation urgente.</span>
+              </article>
+              <article class="faq-item" data-tone="iris">
+                <div class="faq-item-icon" aria-hidden="true">🤖</div>
+                <div class="faq-item-body">
+                  <h3>Que proposent les fonctionnalités IA&nbsp;?</h3>
+                  <p>Trois assistants vous épaulent&nbsp;: un chatbot parental, un générateur d’histoires et des idées de recettes adaptées à l’âge.</p>
+                  <p class="faq-item-note">Bon à savoir&nbsp;: les suggestions restent informatives et ne remplacent pas l’avis de votre pédiatre.</p>
                 </div>
-              </details>
-              <details class="faq-card" data-tone="sea">
-                <summary>
-                  <span class="faq-card-icon" aria-hidden="true">👥</span>
-                  <span class="faq-card-question">Puis‑je inviter un autre parent&nbsp;?</span>
-                  <span class="faq-card-chevron" aria-hidden="true"></span>
-                </summary>
-                <div class="faq-answer">
-                  <p>Oui, partagez votre profil afin que l'autre parent ajoute ses propres observations.</p>
-                  <span class="faq-answer-highlight">Chaque invité possède son espace de notes pour enrichir le journal familial.</span>
+              </article>
+              <article class="faq-item" data-tone="lagoon">
+                <div class="faq-item-icon" aria-hidden="true">👥</div>
+                <div class="faq-item-body">
+                  <h3>Puis-je partager l’accès avec un proche&nbsp;?</h3>
+                  <p>Invitez co-parents, grands-parents ou baby-sitters pour qu’ils contribuent à leur tour au journal familial.</p>
+                  <ul class="faq-item-list">
+                    <li>Chaque invité dispose de ses propres notes.</li>
+                    <li>Les modifications sont historisées pour garder la trace.</li>
+                  </ul>
                 </div>
-              </details>
-              <details class="faq-card" data-tone="mint">
-                <summary>
-                  <span class="faq-card-icon" aria-hidden="true">🔐</span>
-                  <span class="faq-card-question">Mes données sont‑elles sauvegardées&nbsp;?</span>
-                  <span class="faq-card-chevron" aria-hidden="true"></span>
-                </summary>
-                <div class="faq-answer">
-                  <p>Elles restent sur votre appareil tant que vous ne choisissez pas de les synchroniser ou de les exporter.</p>
-                  <span class="faq-answer-highlight">Vous contrôlez totalement l’activation de la synchronisation sécurisée.</span>
+              </article>
+              <article class="faq-item" data-tone="mint">
+                <div class="faq-item-icon" aria-hidden="true">🔐</div>
+                <div class="faq-item-body">
+                  <h3>Comment sont protégées mes données&nbsp;?</h3>
+                  <p>Vos informations restent stockées localement tant que vous n’activez pas la synchronisation sécurisée.</p>
+                  <p class="faq-item-note">Vous choisissez quand exporter, sauvegarder ou supprimer vos données.</p>
                 </div>
-              </details>
-              <details class="faq-card" data-tone="berry">
-                <summary>
-                  <span class="faq-card-icon" aria-hidden="true">📴</span>
-                  <span class="faq-card-question">Synap'Kids fonctionne‑t‑il hors ligne&nbsp;?</span>
-                  <span class="faq-card-chevron" aria-hidden="true"></span>
-                </summary>
-                <div class="faq-answer">
-                  <p>La plupart des outils sont accessibles sans connexion et se synchronisent au retour en ligne.</p>
-                  <span class="faq-answer-highlight">Les mises à jour d’IA se feront automatiquement dès qu’une connexion est disponible.</span>
+              </article>
+              <article class="faq-item" data-tone="peony">
+                <div class="faq-item-icon" aria-hidden="true">💡</div>
+                <div class="faq-item-body">
+                  <h3>Où suggérer une nouvelle idée&nbsp;?</h3>
+                  <p>Partagez vos envies directement depuis la communauté ou écrivez-nous. Chaque demande est examinée lors du comité produit hebdomadaire.</p>
+                  <a class="faq-item-link" href="#/ai">Voir la feuille de route</a>
                 </div>
-              </details>
-              <details class="faq-card" data-tone="gold">
-                <summary>
-                  <span class="faq-card-icon" aria-hidden="true">💡</span>
-                  <span class="faq-card-question">Comment proposer une nouvelle fonctionnalité&nbsp;?</span>
-                  <span class="faq-card-chevron" aria-hidden="true"></span>
-                </summary>
-                <div class="faq-answer">
-                  <p>Écrivez‑nous via la page Contact ou partagez vos idées dans la communauté.</p>
-                  <span class="faq-answer-highlight">Votre suggestion sera étudiée par l’équipe produit chaque semaine.</span>
-                </div>
-              </details>
+              </article>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the FAQ markup on the home page with a two-column layout combining an assistance intro and curated questions
- redesign FAQ cards with cohesive styling, accent colours and supportive highlights to match the rest of the site
- add responsive rules so the new FAQ experience remains accessible on smaller screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce9dbd3cac8321a2897c7b08c959a4