### PR TITLE
Harmonise le module FAQ avec le thème sombre

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1646,9 +1646,9 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   grid-template-columns:minmax(0, .95fr) minmax(0, 1.05fr);
   padding:clamp(32px, 7vw, 60px);
   border-radius:40px;
-  background:linear-gradient(135deg, rgba(255,234,217,.88), rgba(210,222,255,.78));
-  border:1px solid rgba(255,255,255,.55);
-  box-shadow:0 36px 88px rgba(22,34,58,.16);
+  background:linear-gradient(135deg, rgba(15,18,26,.94), rgba(10,11,16,.88));
+  border:1px solid rgba(255,255,255,.16);
+  box-shadow:0 26px 72px rgba(0,0,0,.48);
   overflow:hidden;
   isolation:isolate;
 }
@@ -1658,13 +1658,13 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
 }
 .faq-wrapper::before{
   width:420px; height:420px; top:-180px; right:-160px;
-  background:radial-gradient(circle at center, rgba(255,166,105,.55), rgba(255,166,105,0) 70%);
-  opacity:.6;
+  background:radial-gradient(circle at center, rgba(255,166,105,.38), rgba(255,166,105,0) 70%);
+  opacity:.45;
 }
 .faq-wrapper::after{
   width:460px; height:460px; bottom:-220px; left:-180px;
-  background:radial-gradient(circle at center, rgba(122,158,255,.5), rgba(122,158,255,0) 68%);
-  opacity:.55;
+  background:radial-gradient(circle at center, rgba(122,158,255,.35), rgba(122,158,255,0) 68%);
+  opacity:.4;
 }
 .faq-intro{
   position:relative;
@@ -1685,7 +1685,7 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   margin:0;
   font-size:15px;
   line-height:1.7;
-  color:rgba(30,36,52,.82);
+  color:var(--muted);
 }
 .faq-highlights{
   margin:0;
@@ -1693,7 +1693,7 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   list-style:none;
   display:grid;
   gap:10px;
-  color:rgba(30,36,52,.85);
+  color:var(--text);
   font-size:14.5px;
 }
 .faq-highlights li{
@@ -1702,8 +1702,8 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   gap:10px;
   padding:10px 16px;
   border-radius:18px;
-  background:rgba(255,255,255,.58);
-  box-shadow:inset 0 1px 0 rgba(255,255,255,.68);
+  background:rgba(255,255,255,.08);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.12);
 }
 .faq-highlights span{ font-size:16px; line-height:1; }
 .faq-cta{
@@ -1725,12 +1725,12 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   gap:18px;
   padding:24px 26px;
   border-radius:28px;
-  background:linear-gradient(140deg, rgba(255,255,255,.94), rgba(255,255,255,.78));
-  border:1px solid rgba(255,255,255,.62);
-  box-shadow:0 26px 66px rgba(21,33,58,.14);
+  background:linear-gradient(155deg, rgba(18,22,30,.96), rgba(12,14,20,.9));
+  border:1px solid rgba(255,255,255,.16);
+  box-shadow:0 26px 66px rgba(0,0,0,.46);
   transition:transform .22s ease, box-shadow .28s ease, border-color .28s ease;
   --faq-tone-color:#4254f5;
-  --faq-tone-soft:rgba(66,84,245,.18);
+  --faq-tone-soft:rgba(66,84,245,.28);
   --faq-tone-ring:rgba(66,84,245,.26);
 }
 .faq-item::before{
@@ -1738,14 +1738,14 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   position:absolute;
   inset:0;
   border-radius:inherit;
-  background:linear-gradient(155deg, var(--faq-tone-soft), rgba(255,255,255,0));
-  opacity:.85;
+  background:linear-gradient(155deg, var(--faq-tone-soft), rgba(0,0,0,0));
+  opacity:.65;
   pointer-events:none;
 }
 .faq-item:hover{
   transform:translateY(-4px);
-  box-shadow:0 32px 82px rgba(21,33,58,.18);
-  border-color:rgba(255,255,255,.78);
+  box-shadow:0 34px 88px rgba(0,0,0,.52);
+  border-color:rgba(255,255,255,.26);
 }
 .faq-item-icon{
   position:relative;
@@ -1755,7 +1755,7 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   display:grid;
   place-items:center;
   font-size:24px;
-  background:rgba(255,255,255,.75);
+  background:rgba(255,255,255,.12);
   color:var(--faq-tone-color);
   box-shadow:0 16px 36px var(--faq-tone-ring);
   z-index:1;
@@ -1769,17 +1769,17 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
 .faq-item-body h3{
   margin:0;
   font-size:clamp(17px, 2.2vw, 19px);
-  color:rgba(26,31,45,.96);
+  color:var(--orange-strong);
 }
 .faq-item-body p{
   margin:0;
-  color:rgba(31,36,52,.85);
+  color:var(--text);
   line-height:1.65;
   font-size:15px;
 }
 .faq-item-note{
   font-style:italic;
-  color:rgba(26,31,45,.7);
+  color:rgba(255,255,255,.7);
 }
 .faq-item-list{
   margin:0;
@@ -1788,7 +1788,7 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   display:grid;
   gap:6px;
   font-size:14.5px;
-  color:rgba(31,36,52,.82);
+  color:var(--text);
 }
 .faq-item-list li{
   position:relative;
@@ -1804,7 +1804,7 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   border-radius:50%;
   background:var(--faq-tone-color);
   transform:translateY(-50%);
-  box-shadow:0 0 0 4px rgba(255,255,255,.8);
+  box-shadow:0 0 0 4px rgba(255,255,255,.18);
 }
 .faq-item-link{
   display:inline-flex;


### PR DESCRIPTION
## Summary
- applique un fond sombre en dégradé sur la carte FAQ de la page d’accueil
- ajuste les couleurs du contenu pour conserver les titres orange et rendre les textes descriptifs blancs
- adoucit les accents lumineux et les ombres afin de s’intégrer au style global noir

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce9f8487648321a9ace82c0f117f72