### PR TITLE
Adoucit le relief des cartes IA

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2072,10 +2072,10 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   border:1px solid var(--border);
   background: linear-gradient(135deg, rgba(255,225,200,.14), rgba(183,211,255,.12));
   box-shadow:
-    0 14px 26px rgba(0,0,0,.28),
-    0 4px 10px rgba(0,0,0,.18),
-    inset 0 8px 14px rgba(255,255,255,.05),
-    inset 0 -10px 14px rgba(0,0,0,.22);
+    0 10px 20px rgba(0,0,0,.24),
+    0 3px 8px rgba(0,0,0,.16),
+    inset 0 6px 12px rgba(255,255,255,.04),
+    inset 0 -8px 12px rgba(0,0,0,.18);
   backdrop-filter:blur(10px);
   -webkit-backdrop-filter:blur(10px);
   transition:transform .18s ease, box-shadow .25s ease, border-color .18s ease, background .25s ease;
@@ -2097,10 +2097,10 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
 .ai-tool-bubble:focus-visible{
   transform:translate3d(0, calc(var(--ai-drift) - 4px), 0);
   box-shadow:
-    0 18px 36px rgba(0,0,0,.32),
-    0 6px 14px rgba(0,0,0,.2),
-    inset 0 10px 16px rgba(255,255,255,.06),
-    inset 0 -12px 18px rgba(0,0,0,.26);
+    0 14px 28px rgba(0,0,0,.28),
+    0 5px 12px rgba(0,0,0,.18),
+    inset 0 8px 14px rgba(255,255,255,.05),
+    inset 0 -10px 16px rgba(0,0,0,.22);
   border-color:rgba(255,255,255,.22);
   background: linear-gradient(135deg, rgba(255,225,200,.18), rgba(183,211,255,.16));
 }


### PR DESCRIPTION
## Summary
- adoucit l'effet de relief des bulles de la section "Un outil boosté à l'IA" en réduisant légèrement les ombres portées
- harmonise les ombres en état survol/focus pour conserver un rendu plus doux tout en préservant la profondeur

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cece3adc0c8321ad4112e8421e46ba