### PR TITLE
Ajuste l'historique et améliore les paramètres parent

### DIFF
--- a/api/profiles/update-anon.js
+++ b/api/profiles/update-anon.js
@@ -2,7 +2,9 @@
 const KEY_MAP = {
   fullName: 'full_name',
   avatarUrl: 'avatar_url',
-  avatarURL: 'avatar_url'
+  avatarURL: 'avatar_url',
+  role: 'parent_role',
+  parentRole: 'parent_role'
 };
 
 const DISALLOWED_FIELDS = new Set(['id', 'user_id', 'code_unique', 'created_at', 'updated_at']);
@@ -29,10 +31,34 @@ function normalizeAvatarUrl(value) {
   return value.trim().slice(0, 2048);
 }
 
+const ALLOWED_PARENT_ROLES = new Map([
+  ['maman', 'maman'],
+  ['mere', 'maman'],
+  ['mère', 'maman'],
+  ['papa', 'papa'],
+  ['pere', 'papa'],
+  ['père', 'papa'],
+  ['parent', 'parent'],
+  ['tuteur', 'tuteur'],
+  ['famille', 'famille'],
+  ['autre', 'autre'],
+]);
+
+function normalizeParentRole(value) {
+  if (value === null) return null;
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const lower = trimmed.toLowerCase();
+  if (ALLOWED_PARENT_ROLES.has(lower)) return ALLOWED_PARENT_ROLES.get(lower);
+  return lower.slice(0, 30);
+}
+
 // Applique le normaliseur spécifique selon le champ ciblé
 function normalizeField(key, value) {
   if (key === 'full_name') return normalizeFullName(value);
   if (key === 'avatar_url') return normalizeAvatarUrl(value);
+  if (key === 'parent_role') return normalizeParentRole(value);
   return value;
 }
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -2830,7 +2830,10 @@ try {
           <label>Heure du coucher<input type="time" name="sleep_bedtime" value="${escapeHtml(sleep.bedtime || '')}" /></label>
         </div>
         <h3>Jalons de développement</h3>
-        <div id="edit-milestones">${milestonesHtml}</div>
+        <div class="milestone-toggle">
+          <button type="button" class="btn btn-secondary" id="toggle-milestones" data-expanded="0" aria-expanded="false">Afficher les jalons</button>
+        </div>
+        <div id="edit-milestones" hidden>${milestonesHtml}</div>
         <div class="hstack" style="justify-content:flex-end;"><button type="submit" class="btn btn-primary">Mettre à jour</button></div>
       </form>
     `;
@@ -2838,6 +2841,28 @@ try {
     if (form && !form.dataset.bound) {
       form.addEventListener('submit', handleChildFormSubmit);
       form.dataset.bound = '1';
+    }
+    if (form) {
+      const milestonesBlock = form.querySelector('#edit-milestones');
+      const toggleBtn = form.querySelector('#toggle-milestones');
+      if (milestonesBlock && toggleBtn && !toggleBtn.dataset.bound) {
+        milestonesBlock.hidden = true;
+        toggleBtn.addEventListener('click', () => {
+          const expanded = toggleBtn.dataset.expanded === '1';
+          if (expanded) {
+            milestonesBlock.hidden = true;
+            toggleBtn.dataset.expanded = '0';
+            toggleBtn.setAttribute('aria-expanded', 'false');
+            toggleBtn.textContent = 'Afficher les jalons';
+          } else {
+            milestonesBlock.hidden = false;
+            toggleBtn.dataset.expanded = '1';
+            toggleBtn.setAttribute('aria-expanded', 'true');
+            toggleBtn.textContent = 'Masquer les jalons';
+          }
+        });
+        toggleBtn.dataset.bound = '1';
+      }
     }
   }
 
@@ -2868,7 +2893,7 @@ try {
             await fetch('/api/profiles/update-anon', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ code, fullName: pseudo }),
+              body: JSON.stringify({ code, fullName: pseudo, role }),
             });
           }
         } else {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1014,7 +1014,7 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
 }
 .timeline-comment{
   font-size:13px;
-  color:rgba(0,0,0,.72);
+  color:#ffffff;
 }
 .timeline-comment strong{
   font-weight:600;
@@ -1025,6 +1025,13 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
   margin-top:4px;
 }
 .timeline-actions .btn{
+  min-width:190px;
+}
+.milestone-toggle{
+  display:flex;
+  justify-content:flex-end;
+}
+.milestone-toggle .btn{
   min-width:190px;
 }
 .stack{display:grid; gap:12px}


### PR DESCRIPTION
## Résumé
- Met en blanc les commentaires IA dans l'historique d'évolution du dashboard.
- Ajoute un bouton pour révéler les jalons du profil enfant et masque la section par défaut.
- Permet d'enregistrer le rôle parent pour les profils anonymes lors de la mise à jour du profil.

## Tests
- Non exécutés (non fournis)


------
https://chatgpt.com/codex/tasks/task_e_68cee42ddb2c83219ed2cbda359e0c0b