### PR TITLE
Center child profile buttons and add dashboard reminder popup

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1029,10 +1029,21 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
 }
 .milestone-toggle{
   display:flex;
-  justify-content:flex-end;
+  justify-content:center;
 }
 .milestone-toggle .btn{
   min-width:190px;
+}
+.form-actions-center{
+  display:flex;
+  justify-content:center;
+  gap:12px;
+}
+.dashboard-focus-highlight{
+  outline:3px solid var(--turquoise);
+  box-shadow:0 0 0 6px rgba(255, 194, 214, 0.35);
+  border-radius:18px;
+  transition:box-shadow 0.3s ease, outline-color 0.3s ease;
 }
 .stack{display:grid; gap:12px}
 .hstack{display:flex; gap:12px; align-items:center; flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- center the child profile milestone and submit buttons in the settings form and add styling for focus highlights
- replace the child update alert with a 5-second notification offering "Voir" and "Fermer" actions that can open the dashboard history section
- support focusing the dashboard history card when navigating with the new notification link

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ceffe064c483218593bf02c9fd176b