### PR TITLE
Affiche le nombre d’enfants dans la communauté

### DIFF
--- a/index.html
+++ b/index.html
@@ -825,7 +825,7 @@
             <h3>Confidentialité</h3>
             <label class="switch">
               <input type="checkbox" name="showStats" />
-              <span>Afficher stats dans la communauté</span>
+              <span>Afficher le nombre d’enfant dans la communauté</span>
             </label>
             <label class="switch">
               <input type="checkbox" name="allowMessages" />


### PR DESCRIPTION
## Summary
- augmente la durée du toast affiché après la mise à jour d’un profil enfant
- renomme l’option de confidentialité pour indiquer l’affichage du nombre d’enfants
- ajoute l’affichage conditionnel du nombre d’enfants à côté du nom de l’utilisateur dans les sujets et réponses de la communauté

## Testing
- node --check assets/app.js

------
https://chatgpt.com/codex/tasks/task_e_68cf03a7905883218b999135174e01da