### PR TITLE
Fix community child count visibility

### DIFF
--- a/lib/anon-community.js
+++ b/lib/anon-community.js
@@ -112,20 +112,56 @@ export async function processAnonCommunityRequest(body) {
       replies.forEach((r) => { if (r?.user_id) userIds.add(String(r.user_id)); });
 
       let profiles = [];
+      let showColumn = true;
       if (userIds.size) {
-        const profileParams = new URLSearchParams({ select: 'id,full_name' });
+        const profileParams = new URLSearchParams({ select: 'id,full_name,show_children_count' });
         const filter = buildInFilter(userIds);
         if (filter) profileParams.append('id', filter);
-        const profileData = await supabaseRequest(
-          `${supaUrl}/rest/v1/profiles?${profileParams.toString()}`,
+        try {
+          const profileData = await supabaseRequest(
+            `${supaUrl}/rest/v1/profiles?${profileParams.toString()}`,
+            { headers }
+          );
+          profiles = Array.isArray(profileData) ? profileData : [];
+        } catch (err) {
+          showColumn = false;
+          profileParams.set('select', 'id,full_name');
+          const profileData = await supabaseRequest(
+            `${supaUrl}/rest/v1/profiles?${profileParams.toString()}`,
+            { headers }
+          );
+          profiles = Array.isArray(profileData) ? profileData : [];
+        }
+      }
+
+      const childCounts = new Map();
+      if (userIds.size) {
+        const childParams = new URLSearchParams({ select: 'user_id' });
+        const filter = buildInFilter(userIds);
+        if (filter) childParams.append('user_id', filter);
+        const childData = await supabaseRequest(
+          `${supaUrl}/rest/v1/children?${childParams.toString()}`,
           { headers }
         );
-        profiles = Array.isArray(profileData) ? profileData : [];
+        const rows = Array.isArray(childData) ? childData : [];
+        rows.forEach((row) => {
+          const key = row?.user_id != null ? String(row.user_id) : '';
+          if (!key) return;
+          childCounts.set(key, (childCounts.get(key) || 0) + 1);
+        });
       }
 
       const authors = {};
       profiles.forEach((p) => {
-        if (p?.id) authors[String(p.id)] = p.full_name || '';
+        if (!p?.id) return;
+        const key = String(p.id);
+        const count = childCounts.get(key) ?? 0;
+        const showFlag = showColumn ? !!p.show_children_count : false;
+        authors[key] = {
+          full_name: p.full_name || '',
+          child_count: count,
+          show_children_count: showFlag,
+        };
       });
 
       return {
@@ -254,14 +290,47 @@ export async function processAnonCommunityRequest(body) {
       if (authorIds.length) {
         const authorFilter = buildInFilter(authorIds);
         if (authorFilter) {
-          const authorParams = new URLSearchParams({ select: 'id,full_name' });
+          const authorParams = new URLSearchParams({ select: 'id,full_name,show_children_count' });
           authorParams.append('id', authorFilter);
-          const authorRows = await supabaseRequest(
-            `${supaUrl}/rest/v1/profiles?${authorParams.toString()}`,
+          let authorRows = [];
+          let showColumn = true;
+          try {
+            const rows = await supabaseRequest(
+              `${supaUrl}/rest/v1/profiles?${authorParams.toString()}`,
+              { headers }
+            );
+            authorRows = Array.isArray(rows) ? rows : [];
+          } catch (err) {
+            showColumn = false;
+            authorParams.set('select', 'id,full_name');
+            const rows = await supabaseRequest(
+              `${supaUrl}/rest/v1/profiles?${authorParams.toString()}`,
+              { headers }
+            );
+            authorRows = Array.isArray(rows) ? rows : [];
+          }
+          const childCounts = new Map();
+          const childParams = new URLSearchParams({ select: 'user_id' });
+          childParams.append('user_id', authorFilter);
+          const childRows = await supabaseRequest(
+            `${supaUrl}/rest/v1/children?${childParams.toString()}`,
             { headers }
           );
-          (Array.isArray(authorRows) ? authorRows : []).forEach((p) => {
-            if (p?.id != null) authors[String(p.id)] = p.full_name || '';
+          (Array.isArray(childRows) ? childRows : []).forEach((row) => {
+            const key = row?.user_id != null ? String(row.user_id) : '';
+            if (!key) return;
+            childCounts.set(key, (childCounts.get(key) || 0) + 1);
+          });
+          authorRows.forEach((p) => {
+            if (p?.id == null) return;
+            const key = String(p.id);
+            const count = childCounts.get(key) ?? 0;
+            const showFlag = showColumn ? !!p.show_children_count : false;
+            authors[key] = {
+              full_name: p.full_name || '',
+              child_count: count,
+              show_children_count: showFlag,
+            };
           });
         }
       }


### PR DESCRIPTION
## Summary
- display opt-in child counts for community authors and replies by normalizing author metadata
- persist and reload privacy settings, including the child count toggle, from Supabase for signed-in and anonymous users
- expose child-count visibility metadata through the by-ids profile endpoint and anonymous community API helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf0a2d34c48321a00e91444f3e185d