### PR TITLE
Expose anonymous forum children counts

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1179,7 +1179,24 @@ section[data-route="/community"] .topic-cat{
   border:1px solid rgba(255,255,255,.26);
   color:#ffffff;
 }
-section[data-route="/community"] .topic-author{font-weight:600; color:#ffffff}
+section[data-route="/community"] .topic-author,
+section[data-route="/community"] .reply-author{
+  display:flex;
+  flex-direction:column;
+  align-items:flex-start;
+  gap:2px;
+}
+section[data-route="/community"] .topic-author-name,
+section[data-route="/community"] .reply-author-name{
+  font-weight:600;
+  color:#ffffff;
+}
+section[data-route="/community"] .author-meta{
+  font-size:11px;
+  font-weight:400;
+  color:rgba(226,233,255,.72);
+  line-height:1.2;
+}
 section[data-route="/community"] .topic-title{margin:0; font-size:clamp(22px, 3vw, 28px); font-weight:800; color:#ffffff; text-shadow:0 4px 18px rgba(0,0,0,.5)}
 section[data-route="/community"] .topic-actions{margin-left:auto; display:flex; align-items:center; gap:10px; flex-wrap:wrap}
 section[data-route="/community"] .topic-pill{
@@ -1262,7 +1279,6 @@ section[data-route="/community"] .reply-avatar{
   box-shadow:0 10px 20px rgba(0,0,0,.38);
 }
 section[data-route="/community"] .reply-meta{display:grid; gap:4px; min-width:0}
-section[data-route="/community"] .reply-author{font-weight:600; color:#ffffff}
 section[data-route="/community"] .reply-meta time{font-size:12px; color:rgba(226,233,255,.7)}
 section[data-route="/community"] .reply-body{font-size:14px; line-height:1.6; color:#f0f3ff; word-break:break-word}
 section[data-route="/community"] .btn-message{background:rgba(255,255,255,.1); border:1px solid rgba(255,255,255,.2); color:#ffffff; box-shadow:none}

--- a/lib/anon-community.js
+++ b/lib/anon-community.js
@@ -113,8 +113,9 @@ export async function processAnonCommunityRequest(body) {
 
       let profiles = [];
       let showColumn = true;
+      let includeChildren = true;
       if (userIds.size) {
-        const profileParams = new URLSearchParams({ select: 'id,full_name,show_children_count' });
+        const profileParams = new URLSearchParams({ select: 'id,full_name,show_children_count,children:children(id)' });
         const filter = buildInFilter(userIds);
         if (filter) profileParams.append('id', filter);
         try {
@@ -125,6 +126,7 @@ export async function processAnonCommunityRequest(body) {
           profiles = Array.isArray(profileData) ? profileData : [];
         } catch (err) {
           showColumn = false;
+          includeChildren = false;
           profileParams.set('select', 'id,full_name');
           const profileData = await supabaseRequest(
             `${supaUrl}/rest/v1/profiles?${profileParams.toString()}`,
@@ -134,32 +136,16 @@ export async function processAnonCommunityRequest(body) {
         }
       }
 
-      const childCounts = new Map();
-      if (userIds.size) {
-        const childParams = new URLSearchParams({ select: 'user_id' });
-        const filter = buildInFilter(userIds);
-        if (filter) childParams.append('user_id', filter);
-        const childData = await supabaseRequest(
-          `${supaUrl}/rest/v1/children?${childParams.toString()}`,
-          { headers }
-        );
-        const rows = Array.isArray(childData) ? childData : [];
-        rows.forEach((row) => {
-          const key = row?.user_id != null ? String(row.user_id) : '';
-          if (!key) return;
-          childCounts.set(key, (childCounts.get(key) || 0) + 1);
-        });
-      }
-
       const authors = {};
       profiles.forEach((p) => {
         if (!p?.id) return;
         const key = String(p.id);
-        const count = childCounts.get(key) ?? 0;
+        const childrenCount = includeChildren && Array.isArray(p.children) ? p.children.length : 0;
         const showFlag = showColumn ? !!p.show_children_count : false;
         authors[key] = {
           full_name: p.full_name || '',
-          child_count: count,
+          children_count: childrenCount,
+          child_count: childrenCount,
           show_children_count: showFlag,
         };
       });
@@ -290,10 +276,11 @@ export async function processAnonCommunityRequest(body) {
       if (authorIds.length) {
         const authorFilter = buildInFilter(authorIds);
         if (authorFilter) {
-          const authorParams = new URLSearchParams({ select: 'id,full_name,show_children_count' });
+          const authorParams = new URLSearchParams({ select: 'id,full_name,show_children_count,children:children(id)' });
           authorParams.append('id', authorFilter);
           let authorRows = [];
           let showColumn = true;
+          let includeChildren = true;
           try {
             const rows = await supabaseRequest(
               `${supaUrl}/rest/v1/profiles?${authorParams.toString()}`,
@@ -302,6 +289,7 @@ export async function processAnonCommunityRequest(body) {
             authorRows = Array.isArray(rows) ? rows : [];
           } catch (err) {
             showColumn = false;
+            includeChildren = false;
             authorParams.set('select', 'id,full_name');
             const rows = await supabaseRequest(
               `${supaUrl}/rest/v1/profiles?${authorParams.toString()}`,
@@ -309,26 +297,15 @@ export async function processAnonCommunityRequest(body) {
             );
             authorRows = Array.isArray(rows) ? rows : [];
           }
-          const childCounts = new Map();
-          const childParams = new URLSearchParams({ select: 'user_id' });
-          childParams.append('user_id', authorFilter);
-          const childRows = await supabaseRequest(
-            `${supaUrl}/rest/v1/children?${childParams.toString()}`,
-            { headers }
-          );
-          (Array.isArray(childRows) ? childRows : []).forEach((row) => {
-            const key = row?.user_id != null ? String(row.user_id) : '';
-            if (!key) return;
-            childCounts.set(key, (childCounts.get(key) || 0) + 1);
-          });
           authorRows.forEach((p) => {
             if (p?.id == null) return;
             const key = String(p.id);
-            const count = childCounts.get(key) ?? 0;
+            const childrenCount = includeChildren && Array.isArray(p.children) ? p.children.length : 0;
             const showFlag = showColumn ? !!p.show_children_count : false;
             authors[key] = {
               full_name: p.full_name || '',
-              child_count: count,
+              children_count: childrenCount,
+              child_count: childrenCount,
               show_children_count: showFlag,
             };
           });


### PR DESCRIPTION
## Summary
- fetch community author profiles with embedded children rows to compute child counts directly from Supabase
- surface optional parent metadata beneath author names in the community UI and handle the new structure on the client
- style the author metadata so the children count appears as a small secondary line under the author name

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf152ce37c8321b6dcd66b85e8a1c1