### PR TITLE
Prevent anon profile updates from sending invalid code field

### DIFF
--- a/api/profiles/update-anon.js
+++ b/api/profiles/update-anon.js
@@ -7,7 +7,7 @@ const KEY_MAP = {
   parentRole: 'parent_role'
 };
 
-const DISALLOWED_FIELDS = new Set(['id', 'user_id', 'code_unique', 'created_at', 'updated_at']);
+const DISALLOWED_FIELDS = new Set(['id', 'user_id', 'code_unique', 'code', 'created_at', 'updated_at']);
 
 // Convertit une clé camelCase en snake_case compatible avec la base
 function camelToSnake(key) {


### PR DESCRIPTION
## Summary
- prevent the anonymous profile update endpoint from forwarding the `code` field to Supabase
- ensure preference updates such as show_children_count succeed for anonymous profiles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf183571288321b63be052e5f9d0e0