### PR TITLE
Disable automatic zoom on text inputs

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1285,7 +1285,7 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
 
 .form-grid{display:grid; gap:12px}
 label{display:grid; gap:6px; font-size:14px}
-input, select, textarea{width:100%; background:#ffffff; border:1px solid var(--border); color:var(--text); padding:12px 14px; border-radius:14px; outline:none}
+input, select, textarea{width:100%; background:#ffffff; border:1px solid var(--border); color:var(--text); padding:12px 14px; border-radius:14px; outline:none; font-size:16px}
 input::placeholder, textarea::placeholder{color:#8aa0bf}
 input:focus, select:focus, textarea:focus{box-shadow:0 0 0 2px rgba(138,182,255,.5); border-color:#b9cffd}
 input[type="file"]{padding:8px}
@@ -2578,6 +2578,7 @@ input, select, textarea{
   background:rgba(255,255,255,.08);
   border:1px solid rgba(255,255,255,.22);
   color:#ffffff;
+  font-size:16px;
 }
 input::placeholder, textarea::placeholder{ color:rgba(255,255,255,.55) }
 

--- a/blog.html
+++ b/blog.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <title>Articles de blog</title>
   <link rel="icon" type="image/png" href="/logoonly.png" />
   <link rel="stylesheet" href="assets/style.css?v=6" />

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
  <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
 
   <!-- SEO Meta Tags -->
   <title>Synap'Kids – Accompagner les parents dans les 1000 premiers jours</title>

--- a/la-theorie-de-l-attachement.html
+++ b/la-theorie-de-l-attachement.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <title>La théorie de l'attachement</title>
   <link rel="icon" type="image/png" href="/logoonly.png" />
   <link rel="stylesheet" href="assets/style.css?v=6" />

--- a/la-theorie-de-l-esprit.html
+++ b/la-theorie-de-l-esprit.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <title>La théorie de l’esprit</title>
   <link rel="icon" type="image/png" href="/logoonly.png" />
   <link rel="stylesheet" href="assets/style.css?v=6" />

--- a/les-1000-premiers-jours.html
+++ b/les-1000-premiers-jours.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <title>Les 1000 premiers jours</title>
   <link rel="icon" type="image/png" href="/logoonly.png" />
   <link rel="stylesheet" href="assets/style.css?v=6" />

--- a/messages.html
+++ b/messages.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <title>Messages privés</title>
   <link rel="icon" type="image/png" href="/logoonly.png" />
   <link rel="stylesheet" href="assets/style.css?v=6" />


### PR DESCRIPTION
## Summary
- prevent mobile auto-zoom by constraining the viewport on every standalone HTML page
- enforce a 16px font size for all inputs in both light and dark themes to avoid focus zoom triggers

## Testing
- not run (static changes)

------
https://chatgpt.com/codex/tasks/task_e_68cfc47430ac83218dc19e314dc22ab3