### PR TITLE
Fix child creation primary flag conflicts

### DIFF
--- a/lib/anon-children.js
+++ b/lib/anon-children.js
@@ -258,6 +258,20 @@ function withChildId(records, childId) {
   return records.map(r => ({ ...r, child_id: childId }));
 }
 
+async function hasPrimaryChild(supaUrl, headers, profileId) {
+  try {
+    const data = await supabaseRequest(
+      `${supaUrl}/rest/v1/children?select=id&user_id=eq.${encodeURIComponent(profileId)}&is_primary=eq.true&limit=1`,
+      { headers }
+    );
+    if (Array.isArray(data)) return data.length > 0;
+    return !!data;
+  } catch (err) {
+    console.warn('[anon-children] primary child lookup failed', err);
+    return false;
+  }
+}
+
 /**
  * Point d’entrée unique pour toutes les actions anonymes liées aux enfants.
  * Chaque action valide l’accès via le code anonyme puis appelle Supabase en conséquence.
@@ -318,6 +332,8 @@ export async function processAnonChildrenRequest(body) {
       if (!childPayload.first_name || !childPayload.dob || !childPayload.sex) {
         throw new HttpError(400, 'Invalid child payload');
       }
+      const alreadyHasPrimary = await hasPrimaryChild(supaUrl, headers, profileId);
+      childPayload.is_primary = !alreadyHasPrimary;
       const inserted = await supabaseRequest(
         `${supaUrl}/rest/v1/children`,
         {


### PR DESCRIPTION
## Summary
- ensure the client only marks a new child profile as primary when no primary already exists
- prevent anonymous child creation from failing by forcing the server to skip the primary flag when a primary child already exists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfee6b795c83219f75053a826a4868