### PR TITLE
Add runtime React shim for translation compatibility

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -4,6 +4,7 @@ const NOTIF_BOOT_FLAG = 'pedia_notif_booted';
 // Synap'Kids SPA — Prototype 100 % front avec localStorage + authentification Supabase (Google)
 import { DEV_QUESTIONS } from './questions-dev.js';
 import { loadSupabaseEnv } from './supabase-env-loader.js';
+import { ensureReactGlobals } from './react-shim.js';
 
 const TIMELINE_STAGES = [
   { label: 'Naissance', day: 0, subtitle: '0 j' },
@@ -32,6 +33,11 @@ const TIMELINE_MILESTONES = [
 // import { LENGTH_FOR_AGE, WEIGHT_FOR_AGE, BMI_FOR_AGE } from '/src/data/who-curves.js';
 (async () => {
   document.body.classList.remove('no-js');
+  try {
+    await ensureReactGlobals();
+  } catch (err) {
+    console.warn('Optional React globals failed to load', err);
+  }
   // Forcer l’interface « menu hamburger » sur tous les formats d’écran
   try { document.body.classList.add('force-mobile'); } catch {}
   // Helpers DOM accessibles immédiatement

--- a/assets/blog.js
+++ b/assets/blog.js
@@ -1,6 +1,12 @@
 import { loadSupabaseEnv } from './supabase-env-loader.js';
+import { ensureReactGlobals } from './react-shim.js';
 
 document.body.classList.remove('no-js');
+try {
+  await ensureReactGlobals();
+} catch (err) {
+  console.warn('Optional React globals failed to load', err);
+}
 const $ = (sel, root=document) => root.querySelector(sel);
 const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
 let supabase=null, authSession=null;

--- a/assets/messages.js
+++ b/assets/messages.js
@@ -1,6 +1,12 @@
 import { loadSupabaseEnv } from './supabase-env-loader.js';
+import { ensureReactGlobals } from './react-shim.js';
 
 document.body.classList.remove('no-js');
+try {
+  await ensureReactGlobals();
+} catch (err) {
+  console.warn('Optional React globals failed to load', err);
+}
 const $ = (sel, root=document) => root.querySelector(sel);
 const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
 

--- a/assets/react-shim.js
+++ b/assets/react-shim.js
@@ -1,0 +1,53 @@
+let loadPromise = null;
+
+function loadScriptOnce(src) {
+  return new Promise((resolve, reject) => {
+    if (typeof document === 'undefined') {
+      resolve();
+      return;
+    }
+    const existing = document.querySelector(`script[data-react-shim="${src}"]`);
+    if (existing) {
+      if (existing.dataset.ready === '1') {
+        resolve();
+        return;
+      }
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => reject(new Error(`Failed to load ${src}`)), { once: true });
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = false;
+    script.crossOrigin = 'anonymous';
+    script.dataset.reactShim = src;
+    script.addEventListener('load', () => {
+      script.dataset.ready = '1';
+      resolve();
+    }, { once: true });
+    script.addEventListener('error', () => reject(new Error(`Failed to load ${src}`)), { once: true });
+    document.head.appendChild(script);
+  });
+}
+
+export async function ensureReactGlobals() {
+  if (typeof window === 'undefined') return;
+  if (window.React && window.ReactDOM) return;
+  if (!loadPromise) {
+    loadPromise = (async () => {
+      try {
+        if (!window.React) {
+          await loadScriptOnce('https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js');
+        }
+        if (!window.ReactDOM) {
+          await loadScriptOnce('https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js');
+        }
+      } catch (err) {
+        console.warn('React shim failed to load React libraries', err);
+        loadPromise = null;
+        throw err;
+      }
+    })();
+  }
+  return loadPromise;
+}


### PR DESCRIPTION
## Summary
- add a lightweight runtime shim that loads React and ReactDOM from jsDelivr when they are missing so dynamic translations can access the globals
- initialize the shim from the main SPA, blog, and messages entrypoints to ensure React globals exist before other logic runs

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68cff540d5008321b0390c4883e7262f