### PR TITLE
Use receiver_id for anonymous messages

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -223,13 +223,12 @@ const TIMELINE_MILESTONES = [
   async function anonMessagesRequest(code_unique) {
     const ok = await ensureSupabaseClient();
     if (!ok || !supabase) return [];
-    const code = (code_unique || '').toString().trim().toUpperCase();
-    if (!code) return [];
+    if (code_unique == null || code_unique === '') return [];
     try {
       const { data, error } = await supabase
         .from('messages')
         .select('*')
-        .eq('receiver_code', code)
+        .eq('receiver_id', code_unique)
         .eq('is_read', false)
         .order('created_at', { ascending: false });
 

--- a/assets/messages.js
+++ b/assets/messages.js
@@ -457,13 +457,12 @@ function replayUnseen(){ unseen().forEach(n => { if (n.kind==='msg') { showNotif
 async function anonMessagesRequest(code_unique) {
   const ok = await ensureSupabase();
   if (!ok || !supabase) return [];
-  const code = (code_unique || '').toString().trim().toUpperCase();
-  if (!code) return [];
+  if (code_unique == null || code_unique === '') return [];
   try {
     const { data, error } = await supabase
       .from('messages')
       .select('*')
-      .eq('receiver_code', code)
+      .eq('receiver_id', code_unique)
       .eq('is_read', false)
       .order('created_at', { ascending: false });
     if (error) {


### PR DESCRIPTION
## Summary
- update anonymous message fetching to filter by `receiver_id`
- keep returning only unread messages sorted by newest first

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cffe976144832193d2d7f338bb7973