### PR TITLE
Align onboarding milestone text color

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -421,6 +421,11 @@ section[data-route="/settings"] #edit-milestones .qitem input[type="checkbox"]:f
   outline-offset:3px;
 }
 
+section[data-route="/onboarding"] #dev-questions .qitem label{
+  color:#ffffff;
+  text-shadow:0 1px 10px rgba(0,0,0,.6);
+}
+
 /* keep settings layout stacked (one column) even on wide screens */
 section[data-route="/settings"] .grid-2{ grid-template-columns:1fr !important }
 


### PR DESCRIPTION
## Summary
- update the onboarding milestone labels to use the same white color and shadow as the update form so the texts match

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d008127e648321a771c2ffd1ef412c