### PR TITLE
Fix blog navigation hamburger toggle

### DIFF
--- a/assets/blog.js
+++ b/assets/blog.js
@@ -3,7 +3,12 @@ import { ensureReactGlobals } from './react-shim.js';
 
 document.body.classList.remove('no-js');
 try {
-  await ensureReactGlobals();
+  const maybePromise = ensureReactGlobals();
+  if (maybePromise && typeof maybePromise.then === 'function') {
+    maybePromise.catch(err => {
+      console.warn('Optional React globals failed to load', err);
+    });
+  }
 } catch (err) {
   console.warn('Optional React globals failed to load', err);
 }


### PR DESCRIPTION
## Summary
- replace the blog page's top-level await for React globals with a promise-based call
- ensure the hamburger menu script runs even in browsers without top-level await support

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d022d7dc7c83219481fb6e1ea03fbe