### PR TITLE
Reimagine 1000-day timeline scroll indicator

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -5082,20 +5082,6 @@ const TIMELINE_MILESTONES = [
 
     return `
       ${header}
-        <button type="button" class="timeline-1000__nav timeline-1000__nav--prev" aria-label="Défiler vers la gauche">
-          <span class="timeline-1000__nav-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
-              <path d="M14.53 5.47a.75.75 0 0 1 0 1.06L10.06 11l4.47 4.47a.75.75 0 0 1-1.06 1.06l-5-5a.75.75 0 0 1 0-1.06l5-5a.75.75 0 0 1 1.06 0z" fill="currentColor"/>
-            </svg>
-          </span>
-        </button>
-        <button type="button" class="timeline-1000__nav timeline-1000__nav--next" aria-label="Défiler vers la droite">
-          <span class="timeline-1000__nav-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
-              <path d="M9.47 5.47a.75.75 0 0 0 0 1.06L13.94 11l-4.47 4.47a.75.75 0 1 0 1.06 1.06l5-5a.75.75 0 0 0 0-1.06l-5-5a.75.75 0 0 0-1.06 0z" fill="currentColor"/>
-            </svg>
-          </span>
-        </button>
         <div class="timeline-1000__scroll" role="region" aria-label="Frise des 1000 jours">
           <div class="timeline-1000__track">
             <span class="timeline-1000__line" aria-hidden="true"></span>
@@ -5108,6 +5094,36 @@ const TIMELINE_MILESTONES = [
             </div>
             <div class="timeline-1000__tooltip" role="dialog" aria-live="polite" hidden></div>
           </div>
+        </div>
+        <div class="timeline-1000__nav-bar">
+          <button type="button" class="timeline-1000__nav timeline-1000__nav--prev" aria-label="Défiler vers la gauche">
+            <span class="timeline-1000__nav-icon timeline-1000__nav-icon--prev" aria-hidden="true">
+              <svg viewBox="0 0 64 24" focusable="false" aria-hidden="true" class="timeline-1000__nav-symbol">
+                <path d="M6 12c9-8 22-11 35-7" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-opacity=".55"/>
+                <path d="M6 12c9 8 22 11 35 7" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-opacity=".55"/>
+                <path d="M35 4l15 8-15 8" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                <circle cx="55" cy="12" r="2.2" fill="currentColor" opacity=".85"/>
+                <path d="M55 12l3.2-3.2m-3.2 3.2 3.2 3.2" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" opacity=".85"/>
+              </svg>
+            </span>
+            <span class="timeline-1000__nav-label">Glisser à gauche</span>
+          </button>
+          <div class="timeline-1000__nav-hint">
+            <span class="timeline-1000__nav-hint-track" aria-hidden="true"></span>
+            <span class="timeline-1000__nav-hint-text">Faites défiler pour explorer les 1000 jours</span>
+          </div>
+          <button type="button" class="timeline-1000__nav timeline-1000__nav--next" aria-label="Défiler vers la droite">
+            <span class="timeline-1000__nav-label">Glisser à droite</span>
+            <span class="timeline-1000__nav-icon timeline-1000__nav-icon--next" aria-hidden="true">
+              <svg viewBox="0 0 64 24" focusable="false" aria-hidden="true" class="timeline-1000__nav-symbol">
+                <path d="M6 12c9-8 22-11 35-7" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-opacity=".55"/>
+                <path d="M6 12c9 8 22 11 35 7" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-opacity=".55"/>
+                <path d="M35 4l15 8-15 8" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                <circle cx="55" cy="12" r="2.2" fill="currentColor" opacity=".85"/>
+                <path d="M55 12l3.2-3.2m-3.2 3.2 3.2 3.2" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" opacity=".85"/>
+              </svg>
+            </span>
+          </button>
         </div>
       </section>
     `;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1048,47 +1048,140 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
   background:rgba(255,255,255,.18);
   border-radius:999px;
 }
-.timeline-1000__nav{
-  position:absolute;
-  top:220px;
-  transform:translateY(-50%);
-  width:32px;
-  height:32px;
-  border-radius:50%;
-  border:1px solid rgba(255,255,255,.18);
-  background:rgba(8,10,18,.82);
-  display:grid;
-  place-items:center;
-  color:rgba(255,255,255,.78);
-  font-size:16px;
-  font-weight:700;
-  cursor:pointer;
-  box-shadow:0 12px 28px rgba(0,0,0,.45);
-  transition:transform .18s ease, box-shadow .2s ease, border-color .2s ease, background .2s ease;
-  z-index:6;
-}
-.timeline-1000__nav:hover,
-.timeline-1000__nav:focus-visible{
-  transform:translateY(-50%) scale(1.05);
-  border-color:rgba(255,255,255,.28);
-  box-shadow:0 16px 34px rgba(0,0,0,.5);
-}
-.timeline-1000__nav:focus-visible{ outline:2px solid var(--orange-strong); outline-offset:2px; }
-.timeline-1000__nav[disabled]{ opacity:.35; pointer-events:none; }
-.timeline-1000__nav--prev{ left:6px; }
-.timeline-1000__nav--next{ right:6px; }
-.timeline-1000__nav-icon{
-  pointer-events:none;
+.timeline-1000__nav-bar{
+  margin:22px auto 0;
+  padding:16px 24px;
   display:flex;
   align-items:center;
   justify-content:center;
-  width:100%;
-  height:100%;
+  gap:18px;
+  position:relative;
+  max-width:min(560px, 92%);
+  border-radius:999px;
+  background:linear-gradient(135deg, rgba(183,211,255,.16), rgba(255,194,214,.14));
+  border:1px solid rgba(255,255,255,.16);
+  box-shadow:0 24px 45px rgba(10,18,32,.32);
+  backdrop-filter:blur(18px);
+  -webkit-backdrop-filter:blur(18px);
 }
-.timeline-1000__nav-icon svg{
-  width:14px;
-  height:14px;
+.timeline-1000__nav-bar::before{
+  content:"";
+  position:absolute;
+  inset:-10px;
+  border-radius:inherit;
+  background:linear-gradient(120deg, rgba(255,203,164,.26), rgba(138,182,255,.24));
+  opacity:.45;
+  filter:blur(22px);
+  z-index:-1;
+}
+.timeline-1000__nav{
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  gap:12px;
+  padding:10px 18px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,.24);
+  background:linear-gradient(130deg, rgba(255,203,164,.32), rgba(138,182,255,.32));
+  color:#ffffff;
+  font-size:12px;
+  font-weight:700;
+  letter-spacing:.12em;
+  text-transform:uppercase;
+  cursor:pointer;
+  box-shadow:0 16px 32px rgba(8,12,24,.32);
+  transition:transform .2s ease, box-shadow .2s ease, border-color .2s ease, background .2s ease;
+  white-space:nowrap;
+}
+.timeline-1000__nav:hover,
+.timeline-1000__nav:focus-visible{
+  transform:translateY(-2px);
+  border-color:rgba(255,255,255,.45);
+  box-shadow:0 22px 40px rgba(8,12,24,.38);
+  background:linear-gradient(130deg, rgba(255,203,164,.42), rgba(138,182,255,.42));
+}
+.timeline-1000__nav:focus-visible{ outline:2px solid var(--orange-strong); outline-offset:2px; }
+.timeline-1000__nav[disabled]{ opacity:.45; pointer-events:none; transform:none; box-shadow:none; }
+.timeline-1000__nav-label{ color:#ffffff; font-size:12px; letter-spacing:.16em; }
+.timeline-1000__nav-icon{
+  pointer-events:none;
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:58px;
+  height:32px;
+  border-radius:999px;
+  overflow:hidden;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.18);
+}
+.timeline-1000__nav-icon::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(120deg, rgba(255,150,64,.28), rgba(142,182,255,.24));
+  opacity:.65;
+}
+.timeline-1000__nav-icon--prev{ transform:scaleX(-1); }
+.timeline-1000__nav-symbol{
+  width:48px;
+  height:22px;
   display:block;
+  position:relative;
+  z-index:1;
+  color:#ffffff;
+}
+.timeline-1000__nav-hint{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:10px;
+  min-width:200px;
+  text-align:center;
+}
+.timeline-1000__nav-hint-track{
+  position:relative;
+  width:220px;
+  max-width:100%;
+  height:8px;
+  border-radius:999px;
+  background:rgba(255,255,255,.18);
+  overflow:hidden;
+}
+.timeline-1000__nav-hint-track::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(90deg, rgba(138,182,255,.25), rgba(255,150,64,.25));
+}
+.timeline-1000__nav-hint-track::after{
+  content:"";
+  position:absolute;
+  top:50%;
+  width:18px;
+  height:18px;
+  border-radius:50%;
+  transform:translate(-50%,-50%);
+  background:linear-gradient(135deg, var(--orange-strong), var(--violet-strong));
+  box-shadow:0 0 12px rgba(255,150,64,.55), 0 0 24px rgba(138,182,255,.35);
+  animation:timeline-nav-indicator 3.2s ease-in-out infinite;
+}
+.timeline-1000__nav-hint-text{
+  font-size:12px;
+  letter-spacing:.14em;
+  text-transform:uppercase;
+  font-weight:700;
+  color:rgba(255,255,255,.78);
+  max-width:260px;
+  line-height:1.4;
+}
+@keyframes timeline-nav-indicator{
+  0%{ left:14%; opacity:.6; }
+  50%{ left:86%; opacity:1; }
+  100%{ left:14%; opacity:.6; }
+}
+@media (prefers-reduced-motion:reduce){
+  .timeline-1000__nav-hint-track::after{ animation:none; left:50%; opacity:.8; }
 }
 .timeline-1000__track{
   position:relative;
@@ -1287,7 +1380,7 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
 
 @media(max-width:900px){
   .timeline-1000__track{ min-width:900px; padding:260px 28px 80px; }
-  .timeline-1000__nav{ top:240px; }
+  .timeline-1000__nav-bar{ margin-top:18px; padding:14px 20px; gap:16px; }
   .timeline-1000__line,
   .timeline-1000__progress,
   .timeline-1000__point,
@@ -1295,9 +1388,23 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
   .timeline-1000__tooltip{ top:240px; }
   .timeline-1000__tick::after{ height:200px; }
 }
+@media(max-width:720px){
+  .timeline-1000__nav-bar{
+    flex-direction:column;
+    align-items:stretch;
+    max-width:100%;
+    padding:18px 18px;
+    gap:14px;
+  }
+  .timeline-1000__nav{ width:100%; justify-content:space-between; }
+  .timeline-1000__nav-label{ letter-spacing:.1em; }
+  .timeline-1000__nav-icon{ width:52px; }
+  .timeline-1000__nav-hint{ width:100%; }
+  .timeline-1000__nav-hint-track{ width:100%; }
+}
 @media(max-width:640px){
   .timeline-1000__track{ min-width:700px; padding:290px 24px 76px; }
-  .timeline-1000__nav{ top:260px; }
+  .timeline-1000__nav-bar{ padding:20px 18px; }
   .timeline-1000__line,
   .timeline-1000__progress,
   .timeline-1000__point,


### PR DESCRIPTION
## Summary
- replace the timeline arrow controls with a gradient bottom navigation bar and contextual labels
- add an animated scroll hint that matches the brand palette and guides users across the 1000-day frieze

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0284c70d88321b2440de4847ffd67