### PR TITLE
Simplify 1000-day timeline scroll hint

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -5095,22 +5095,11 @@ const TIMELINE_MILESTONES = [
             <div class="timeline-1000__tooltip" role="dialog" aria-live="polite" hidden></div>
           </div>
         </div>
-        <div class="timeline-1000__nav-bar" role="navigation" aria-label="Contrôle de défilement de la frise">
-          <button type="button" class="timeline-1000__nav timeline-1000__nav--prev" aria-label="Défiler vers la gauche">
-            <span class="timeline-1000__nav-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true" class="timeline-1000__nav-symbol">
-                <path d="M14.5 6.5 9 12l5.5 5.5M19.5 12H9" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </span>
-          </button>
+        <div class="timeline-1000__nav-bar" role="note" aria-label="Astuce de défilement de la frise">
+          <span class="timeline-1000__nav-hint" aria-hidden="true">
+            <span class="timeline-1000__nav-hint-icon">⇆</span>
+          </span>
           <span class="timeline-1000__nav-hint-text">Faites défiler pour explorer les 1000 jours</span>
-          <button type="button" class="timeline-1000__nav timeline-1000__nav--next" aria-label="Défiler vers la droite">
-            <span class="timeline-1000__nav-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true" class="timeline-1000__nav-symbol">
-                <path d="M9.5 6.5 15 12l-5.5 5.5M4.5 12H15" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </span>
-          </button>
         </div>
       </section>
     `;
@@ -5140,26 +5129,29 @@ const TIMELINE_MILESTONES = [
 
     const navPrev = root.querySelector('.timeline-1000__nav--prev');
     const navNext = root.querySelector('.timeline-1000__nav--next');
+    let updateNavState = null;
 
-    const updateNavState = () => {
-      const maxScroll = track.scrollWidth - scroller.clientWidth;
-      if (navPrev) navPrev.disabled = scroller.scrollLeft <= 8;
-      if (navNext) navNext.disabled = scroller.scrollLeft >= maxScroll - 8;
-    };
+    if (navPrev || navNext) {
+      const scrollByDelta = (delta) => {
+        const target = scroller.scrollLeft + delta;
+        const maxScroll = track.scrollWidth - scroller.clientWidth;
+        const next = clamp(target, 0, Math.max(0, maxScroll));
+        scroller.scrollTo({ left: next, behavior: 'smooth' });
+      };
 
-    const scrollByDelta = (delta) => {
-      const target = scroller.scrollLeft + delta;
-      const maxScroll = track.scrollWidth - scroller.clientWidth;
-      const next = clamp(target, 0, Math.max(0, maxScroll));
-      scroller.scrollTo({ left: next, behavior: 'smooth' });
-    };
+      const step = () => Math.max(200, Math.round(scroller.clientWidth * 0.6));
 
-    const step = () => Math.max(200, Math.round(scroller.clientWidth * 0.6));
+      navPrev?.addEventListener('click', () => scrollByDelta(-step()));
+      navNext?.addEventListener('click', () => scrollByDelta(step()));
 
-    navPrev?.addEventListener('click', () => scrollByDelta(-step()));
-    navNext?.addEventListener('click', () => scrollByDelta(step()));
+      updateNavState = () => {
+        const maxScroll = track.scrollWidth - scroller.clientWidth;
+        if (navPrev) navPrev.disabled = scroller.scrollLeft <= 8;
+        if (navNext) navNext.disabled = scroller.scrollLeft >= maxScroll - 8;
+      };
 
-    updateNavState();
+      updateNavState();
+    }
 
     let activePoint = null;
     let hideTimer = null;
@@ -5245,7 +5237,7 @@ const TIMELINE_MILESTONES = [
     tooltip.addEventListener('mouseleave', scheduleHide);
 
     scroller.addEventListener('scroll', () => {
-      updateNavState();
+      if (typeof updateNavState === 'function') updateNavState();
       if (!tooltip.hidden) positionTooltip();
     }, { passive: true });
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1050,65 +1050,34 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
 }
 .timeline-1000__nav-bar{
   margin:18px auto 0;
-  padding:8px 14px;
   display:flex;
+  flex-direction:column;
   align-items:center;
   justify-content:center;
-  gap:12px;
-  flex-wrap:wrap;
-  max-width:min(380px, 92%);
-  border-radius:999px;
-  background:rgba(10,16,28,.45);
-  border:1px solid rgba(255,255,255,.12);
-  color:rgba(255,255,255,.82);
+  gap:6px;
+  max-width:min(360px, 92%);
+  color:rgba(255,255,255,.78);
   font-size:12px;
-  font-weight:600;
   letter-spacing:.02em;
-  line-height:1.5;
   text-align:center;
-  backdrop-filter:blur(10px);
-  -webkit-backdrop-filter:blur(10px);
 }
-.timeline-1000__nav{
+.timeline-1000__nav-hint{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  width:38px;
-  height:38px;
+  width:32px;
+  height:32px;
   border-radius:50%;
-  border:1px solid rgba(255,255,255,.18);
   background:rgba(255,255,255,.08);
-  color:#ffffff;
-  cursor:pointer;
-  transition:background .2s ease, border-color .2s ease, transform .2s ease, box-shadow .2s ease;
-  box-shadow:none;
-}
-.timeline-1000__nav:hover,
-.timeline-1000__nav:focus-visible{
-  background:rgba(255,255,255,.16);
-  border-color:rgba(255,255,255,.36);
-  transform:translateY(-1px);
-  box-shadow:0 12px 24px rgba(8,12,24,.26);
-}
-.timeline-1000__nav:focus-visible{ outline:2px solid var(--orange-strong); outline-offset:2px; }
-.timeline-1000__nav[disabled]{ opacity:.45; pointer-events:none; transform:none; box-shadow:none; }
-.timeline-1000__nav-icon{
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  width:18px;
-  height:18px;
-}
-.timeline-1000__nav-symbol{
-  display:block;
-  width:100%;
-  height:100%;
+  box-shadow:0 0 0 1px rgba(255,255,255,.18);
+  color:rgba(255,255,255,.88);
+  font-size:14px;
+  font-weight:600;
+  line-height:1;
 }
 .timeline-1000__nav-hint-text{
-  flex:1 1 160px;
   color:rgba(255,255,255,.75);
   font-size:12px;
-  letter-spacing:.02em;
   font-weight:500;
   line-height:1.6;
 }
@@ -1309,7 +1278,7 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
 
 @media(max-width:900px){
   .timeline-1000__track{ min-width:900px; padding:260px 28px 80px; }
-  .timeline-1000__nav-bar{ margin-top:16px; padding:8px 12px; gap:10px; }
+  .timeline-1000__nav-bar{ margin-top:16px; gap:4px; }
   .timeline-1000__line,
   .timeline-1000__progress,
   .timeline-1000__point,
@@ -1318,13 +1287,12 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
   .timeline-1000__tick::after{ height:200px; }
 }
 @media(max-width:720px){
-  .timeline-1000__nav-bar{ max-width:100%; padding:10px 12px; gap:10px; }
-  .timeline-1000__nav{ width:34px; height:34px; }
-  .timeline-1000__nav-hint-text{ flex-basis:100%; font-size:11px; letter-spacing:.02em; }
+  .timeline-1000__nav-bar{ max-width:100%; }
+  .timeline-1000__nav-hint{ width:28px; height:28px; font-size:13px; }
+  .timeline-1000__nav-hint-text{ font-size:11px; letter-spacing:.02em; }
 }
 @media(max-width:640px){
   .timeline-1000__track{ min-width:700px; padding:290px 24px 76px; }
-  .timeline-1000__nav-bar{ padding:8px 12px; }
   .timeline-1000__line,
   .timeline-1000__progress,
   .timeline-1000__point,


### PR DESCRIPTION
## Summary
- replace the navigation pill on the 1000-day timeline with a lightweight scroll hint that keeps the instructional text
- clean up related styles and make the hint responsive while preserving accessibility hooks
- guard the timeline scroller logic so it tolerates the absence of explicit navigation buttons

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d02e0b06ac83219d8ad4458245571d