### PR TITLE
Reduce spacing between timeline and nav hint

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1040,7 +1040,7 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
   position:relative;
   overflow-x:auto;
   overflow-y:visible;
-  padding-bottom:8px;
+  padding-bottom:4px;
   margin-top:10px;
 }
 .timeline-1000__scroll::-webkit-scrollbar{ height:6px; }
@@ -1049,7 +1049,7 @@ section[data-route="/"] .card{position:relative; overflow:hidden}
   border-radius:999px;
 }
 .timeline-1000__nav-bar{
-  margin:12px auto 0;
+  margin:6px auto 0;
   display:flex;
   flex-direction:column;
   align-items:center;


### PR DESCRIPTION
## Summary
- decrease the bottom padding of the 1000 days timeline scroll container to tighten spacing
- reduce the top margin of the scroll hint bar so it sits closer to the timeline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d034c202c083218efe700611dc8776