### PR TITLE
Generate AI summaries and comments for child updates

### DIFF
--- a/lib/anon-children.js
+++ b/lib/anon-children.js
@@ -9,6 +9,8 @@ const CHILD_TEXT_FIELDS = [
   'sleep_wake_duration',
 ];
 
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
+
 // Erreur HTTP enrichie utilisée pour faire remonter proprement les statuts Supabase
 class HttpError extends Error {
   constructor(status, message, details) {
@@ -50,6 +52,129 @@ async function supabaseRequest(url, options = {}) {
     throw new HttpError(res.status, 'Supabase error', json ?? text);
   }
   return json;
+}
+
+function limitString(value, max = 600) {
+  if (typeof value !== 'string') return '';
+  return value.trim().slice(0, max);
+}
+
+function sanitizeForPrompt(value, depth = 0) {
+  if (depth > 3) return '[...]';
+  if (typeof value === 'string') return value.slice(0, 400);
+  if (Array.isArray(value)) {
+    return value.slice(0, 10).map(entry => sanitizeForPrompt(entry, depth + 1));
+  }
+  if (!value || typeof value !== 'object') return value;
+  const entries = Object.entries(value).slice(0, 20);
+  const out = {};
+  for (const [key, val] of entries) {
+    out[key] = sanitizeForPrompt(val, depth + 1);
+  }
+  return out;
+}
+
+function parseUpdateContent(raw) {
+  if (!raw) return {};
+  if (typeof raw === 'object') {
+    try { return JSON.parse(JSON.stringify(raw)); }
+    catch { return { ...raw }; }
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return {};
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === 'object') return parsed;
+      return { summary: trimmed };
+    } catch {
+      return { summary: trimmed };
+    }
+  }
+  return {};
+}
+
+function extractParentComment(updateObject) {
+  if (!updateObject || typeof updateObject !== 'object') return '';
+  const comment = updateObject.userComment;
+  if (typeof comment !== 'string') return '';
+  return limitString(comment, 600);
+}
+
+function buildUpdateText(updateType, updateObject) {
+  const payload = {
+    type: updateType || 'update',
+    data: sanitizeForPrompt(updateObject || {})
+  };
+  return JSON.stringify(payload).slice(0, 4000);
+}
+
+async function fetchRecentSummaries(supaUrl, headers, childId, limit = 10) {
+  try {
+    const data = await supabaseRequest(
+      `${supaUrl}/rest/v1/child_updates?select=ai_summary&child_id=eq.${encodeURIComponent(childId)}&ai_summary=not.is.null&order=created_at.desc&limit=${Math.max(1, Math.min(10, limit))}`,
+      { headers }
+    );
+    const rows = Array.isArray(data) ? data : [];
+    return rows
+      .map(row => typeof row?.ai_summary === 'string' ? row.ai_summary.trim() : '')
+      .filter(Boolean);
+  } catch (err) {
+    console.warn('[anon-children] failed to fetch ai_summary history', err);
+    return [];
+  }
+}
+
+async function callOpenAi(messages, { temperature = 0.4 } = {}) {
+  if (!OPENAI_API_KEY) return '';
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${OPENAI_API_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ model: 'gpt-4o-mini', temperature, messages })
+  });
+  if (!res.ok) {
+    const details = await res.text().catch(() => '');
+    console.warn('[anon-children] OpenAI chat error', res.status, details);
+    return '';
+  }
+  const json = await res.json().catch(() => null);
+  return json?.choices?.[0]?.message?.content?.trim() || '';
+}
+
+async function generateAiSummary(updateType, updateText, parentComment) {
+  if (!OPENAI_API_KEY || !updateText) return '';
+  const system = "Tu es Ped’IA. Résume factuellement la mise à jour fournie en français, en 50 mots maximum. Bannis toute donnée extérieure et concentre-toi uniquement sur la mise à jour et le commentaire parent.";
+  const userParts = [];
+  if (updateType) userParts.push(`Type de mise à jour: ${updateType}`);
+  userParts.push(`Mise à jour (JSON): ${updateText}`);
+  userParts.push(`Commentaire du parent: ${parentComment || 'Aucun'}`);
+  const user = userParts.join('\n\n');
+  return callOpenAi([
+    { role: 'system', content: system },
+    { role: 'user', content: user }
+  ], { temperature: 0.2 });
+}
+
+async function generateAiCommentaire(updateType, updateText, parentComment, previousSummaries, latestSummary) {
+  if (!OPENAI_API_KEY) return '';
+  const history = Array.isArray(previousSummaries) && previousSummaries.length
+    ? previousSummaries.map((s, idx) => `${idx + 1}. ${s}`).join('\n')
+    : 'Aucun historique disponible';
+  const system = "Tu es Ped’IA, assistant parental bienveillant. Rédige un commentaire personnalisé (80 mots max) basé uniquement sur la nouvelle mise à jour, le commentaire parent et les résumés factuels fournis. Ne réutilise jamais d’anciens commentaires IA. Sois chaleureux, concret et rassurant.";
+  const parts = [];
+  if (updateType) parts.push(`Type de mise à jour: ${updateType}`);
+  parts.push(`Historique des résumés (du plus récent au plus ancien):\n${history}`);
+  if (latestSummary) parts.push(`Résumé factuel de la nouvelle mise à jour: ${latestSummary}`);
+  parts.push(`Nouvelle mise à jour détaillée (JSON): ${updateText}`);
+  parts.push(`Commentaire du parent: ${parentComment || 'Aucun'}`);
+  const user = parts.join('\n\n');
+  return callOpenAi([
+    { role: 'system', content: system },
+    { role: 'user', content: user }
+  ], { temperature: 0.35 });
 }
 
 // Normalise une chaîne en limitant sa longueur et en gérant éventuellement les valeurs nulles
@@ -481,10 +606,24 @@ export async function processAnonChildrenRequest(body) {
       if (child.user_id !== profileId) throw new HttpError(403, 'Forbidden');
       const updateType = normalizeString(body.updateType ?? body.type ?? '', 64);
       const contentRaw = body.updateContent ?? body.content ?? {};
-      const updateContent = typeof contentRaw === 'string' ? contentRaw : JSON.stringify(contentRaw);
-      const aiComment = body.aiComment != null ? normalizeString(body.aiComment, 5000, { allowNull: true }) : null;
-      const payload = { child_id: childId, update_type: updateType || 'update', update_content: updateContent };
-      if (aiComment != null) payload.ai_comment = aiComment;
+      const parsedContent = parseUpdateContent(contentRaw);
+      const updateContent = JSON.stringify(parsedContent ?? {});
+      const parentComment = extractParentComment(parsedContent);
+      const updateText = buildUpdateText(updateType, parsedContent);
+      let aiSummary = '';
+      let aiCommentaire = '';
+      if (OPENAI_API_KEY) {
+        aiSummary = await generateAiSummary(updateType, updateText, parentComment);
+        const previousSummaries = await fetchRecentSummaries(supaUrl, headers, childId, 10);
+        aiCommentaire = await generateAiCommentaire(updateType, updateText, parentComment, previousSummaries, aiSummary);
+      }
+      const payload = {
+        child_id: childId,
+        update_type: updateType || 'update',
+        update_content: updateContent,
+      };
+      if (aiSummary) payload.ai_summary = aiSummary;
+      if (aiCommentaire) payload.ai_commentaire = aiCommentaire;
       const inserted = await supabaseRequest(
         `${supaUrl}/rest/v1/child_updates`,
         {


### PR DESCRIPTION
## Summary
- add server-side helpers to parse updates, call OpenAI and persist `ai_summary`/`ai_commentaire`
- extend the anonymous child update flow to build condensed histories before generating comments
- update the SPA to fetch summary history, call the new `/api/ai` mode and store the new columns when logging updates

## Testing
- node --check api/ai.js
- node --check lib/anon-children.js
- node --check assets/app.js

------
https://chatgpt.com/codex/tasks/task_e_68d0696167b08321b1868cd6e062e020