### PR TITLE
Fix AI route background canvas layering

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1836,6 +1836,10 @@ section[data-route="/ai"] .card{
   box-shadow: none !important;
   background: transparent !important;
 }
+section[data-route="/ai"] > .route-canvas{
+  z-index: -1;
+  opacity: .45;
+}
 /* Exception: keep a frame for the profile indicator empty state */
 section[data-route="/ai"] #ai-profile-indicator{
   border: 1px solid var(--border) !important;


### PR DESCRIPTION
## Summary
- keep the AI feature page background canvas behind the cards to prevent bubbles from overlapping the content
- soften the canvas opacity so the animation remains visible without washing out the UI

## Testing
- Manually opened http://localhost:3000/#/ai

------
https://chatgpt.com/codex/tasks/task_e_68d117565bd4832190403acf0c633983