### PR TITLE
Fix AI feature canvas layering

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1837,7 +1837,7 @@ section[data-route="/ai"] .card{
   background: transparent !important;
 }
 section[data-route="/ai"] > .route-canvas{
-  z-index: -1;
+  z-index: 1;
   opacity: .45;
 }
 /* Exception: keep a frame for the profile indicator empty state */


### PR DESCRIPTION
## Summary
- restore the AI feature route canvas z-index so the bubble animation renders above the cards again

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d119d30f408321bb8a889aeeea3d68