### PR TITLE
Ajuste du logo mobile sur pages internes

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -271,6 +271,9 @@ section{opacity:.8}
   .page-logo-img {
     height: clamp(140px, 20vw, 300px); /* logo principal légèrement agrandi sur mobile */
   }
+  .interior-page .page-logo-img {
+    height: clamp(160px, 24vw, 320px); /* logo des pages internes un peu plus grand sur mobile */
+  }
 }
 
 

--- a/blog.html
+++ b/blog.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/png" href="/logoonly.png" />
   <link rel="stylesheet" href="assets/style.css?v=6" />
 </head>
-<body class="no-js">
+<body class="no-js interior-page">
   <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Forcer le chargement</button></div>
   <header class="site-header">
     <div class="container header-inner">

--- a/la-theorie-de-l-attachement.html
+++ b/la-theorie-de-l-attachement.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/png" href="/logoonly.png" />
   <link rel="stylesheet" href="assets/style.css?v=6" />
 </head>
-<body class="no-js">
+<body class="no-js interior-page">
   <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Forcer le chargement</button></div>
   <header class="site-header">
     <div class="container header-inner">

--- a/la-theorie-de-l-esprit.html
+++ b/la-theorie-de-l-esprit.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/png" href="/logoonly.png" />
   <link rel="stylesheet" href="assets/style.css?v=6" />
 </head>
-<body class="no-js">
+<body class="no-js interior-page">
   <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Forcer le chargement</button></div>
   <header class="site-header">
     <div class="container header-inner">

--- a/les-1000-premiers-jours.html
+++ b/les-1000-premiers-jours.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/png" href="/logoonly.png" />
   <link rel="stylesheet" href="assets/style.css?v=6" />
 </head>
-<body class="no-js">
+<body class="no-js interior-page">
   <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Forcer le chargement</button></div>
   <header class="site-header">
     <div class="container header-inner">

--- a/messages.html
+++ b/messages.html
@@ -33,7 +33,7 @@
       }
   </style>
 </head>
-<body class="no-js">
+<body class="no-js interior-page">
   <div id="loading-overlay"><div class="loader"></div><button id="refresh-btn" class="btn btn-secondary" hidden>Forcer le chargement</button></div>
   <header class="site-header">
     <div class="container header-inner">


### PR DESCRIPTION
## Summary
- ajoute la classe `interior-page` sur les pages internes pour cibler leurs styles mobiles
- augmente légèrement la hauteur du logo sous le header sur mobile pour les pages internes

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d13369ee988321bf3eab12418c2840