### PR TITLE
Finalize family context updates and family view

### DIFF
--- a/api/ai.js
+++ b/api/ai.js
@@ -1,5 +1,51 @@
 import { HttpError, getServiceConfig, supabaseRequest } from '../lib/anon-children.js';
 
+const PARENT_CONTEXT_FIELD_LABELS = {
+  full_name: 'Pseudo',
+  parent_role: 'Rôle affiché',
+  marital_status: 'Statut marital',
+  number_of_children: 'Nombre d’enfants',
+  parental_employment: 'Situation professionnelle',
+  parental_emotion: 'État émotionnel',
+  parental_stress: 'Niveau de stress',
+  parental_fatigue: 'Niveau de fatigue',
+};
+
+const PARENT_CONTEXT_VALUE_LABELS = {
+  marital_status: {
+    marie: 'Marié·e / Pacsé·e',
+    couple: 'En couple',
+    celibataire: 'Célibataire',
+    separe: 'Séparé·e / Divorcé·e',
+    veuf: 'Veuf / Veuve',
+    autre: 'Autre',
+  },
+  parental_employment: {
+    conge_parental: 'Congé parental',
+    temps_plein: 'Temps plein',
+    temps_partiel: 'Temps partiel',
+    horaires_decales: 'Horaires décalés / Nuit',
+    sans_emploi: 'Sans emploi / Entre deux',
+    autre: 'Autre',
+  },
+  parental_emotion: {
+    positif: 'Positif / serein',
+    neutre: 'Neutre',
+    fragile: 'Fragile / sensible',
+    anxieux: 'Anxieux / stressé',
+  },
+  parental_stress: {
+    faible: 'Faible',
+    modere: 'Modéré',
+    eleve: 'Élevé',
+  },
+  parental_fatigue: {
+    faible: 'Faible',
+    modere: 'Modérée',
+    eleve: 'Élevée',
+  },
+};
+
 // Fonction serverless unique : /api/ai (regroupe story, advice, comment, recipes)
 export default async function handler(req, res) {
   if (req.method === 'OPTIONS') {
@@ -137,6 +183,8 @@ Prends en compte les champs du profil (allergies, type d’alimentation, style d
               .filter(Boolean)
               .slice(0, 10)
           : [];
+        const parentContext = sanitizeParentContextInput(body.parentContext);
+        const parentContextLines = parentContextToPromptLines(parentContext);
         const updateText = JSON.stringify({ type: updateType || 'update', data: updateForPrompt }).slice(0, 4000);
         const summaryMessages = [
           { role: 'system', content: "Tu es Ped’IA. Résume factuellement la mise à jour fournie en français en 50 mots maximum. Utilise uniquement les informations transmises (mise à jour + commentaire parent)." },
@@ -171,13 +219,16 @@ Prends en compte les champs du profil (allergies, type d’alimentation, style d
           ? historySummaries.map((entry, idx) => `${idx + 1}. ${entry}`).join('\n')
           : 'Aucun historique disponible';
         const commentMessages = [
-          { role: 'system', content: "Tu es Ped’IA, assistant parental bienveillant. Rédige un commentaire personnalisé (80 mots max) basé uniquement sur la nouvelle mise à jour, le commentaire parent et les résumés factuels fournis. Ne réutilise jamais d’anciens commentaires IA." },
+          { role: 'system', content: "Tu es Ped’IA, assistant parental bienveillant. Rédige un commentaire personnalisé (80 mots max) basé uniquement sur la nouvelle mise à jour, le commentaire parent et les résumés factuels fournis. Prends en compte le contexte parental (stress, fatigue, émotions) pour adapter ton empathie et tes conseils. Ne réutilise jamais d’anciens commentaires IA." },
           { role: 'user', content: [
             updateType ? `Type de mise à jour: ${updateType}` : '',
             `Historique des résumés (du plus récent au plus ancien):\n${historyText}`,
             summary ? `Résumé factuel de la nouvelle mise à jour: ${summary}` : '',
             `Nouvelle mise à jour détaillée (JSON): ${updateText || 'Aucune donnée'}`,
-            `Commentaire du parent: ${parentComment || 'Aucun'}`
+            `Commentaire du parent: ${parentComment || 'Aucun'}`,
+            parentContextLines.length
+              ? `Contexte parental actuel:\n${parentContextLines.map((line) => `- ${line}`).join('\n')}`
+              : 'Contexte parental actuel: non précisé.'
           ].filter(Boolean).join('\n\n') }
         ];
         let comment = '';
@@ -204,6 +255,139 @@ Prends en compte les champs du profil (allergies, type d’alimentation, style d
         res.setHeader('Access-Control-Allow-Origin', '*');
         res.setHeader('Content-Type', 'application/json; charset=utf-8');
         return res.status(200).send(JSON.stringify({ summary, comment }));
+      }
+      case 'family-bilan': {
+        const apiKey = process.env.OPENAI_API_KEY;
+        if (!apiKey) return res.status(500).json({ error: 'Missing OPENAI_API_KEY' });
+        const profileIdCandidates = [
+          typeof body.profileId === 'string' ? body.profileId.trim() : '',
+          typeof body.profile_id === 'string' ? body.profile_id.trim() : '',
+          typeof req?.query?.profileId === 'string' ? req.query.profileId.trim() : '',
+          typeof req?.query?.profile_id === 'string' ? req.query.profile_id.trim() : '',
+        ];
+        const profileId = profileIdCandidates.find(Boolean)?.slice(0, 128) || '';
+        if (!profileId) {
+          return res.status(400).json({ error: 'profileId required' });
+        }
+        const { supaUrl, serviceKey } = getServiceConfig();
+        const headers = { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` };
+        let profileRow = null;
+        let childrenRows = [];
+        let childUpdates = [];
+        let parentUpdates = [];
+        try {
+          const [profileData, childrenData] = await Promise.all([
+            supabaseRequest(
+              `${supaUrl}/rest/v1/profiles?select=full_name,parent_role,marital_status,number_of_children,parental_employment,parental_emotion,parental_stress,parental_fatigue,context_parental&id=eq.${encodeURIComponent(profileId)}&limit=1`,
+              { headers }
+            ),
+            supabaseRequest(
+              `${supaUrl}/rest/v1/children?select=id,first_name,sex,dob&user_id=eq.${encodeURIComponent(profileId)}&order=dob.asc`,
+              { headers }
+            ),
+          ]);
+          profileRow = Array.isArray(profileData) ? profileData[0] : profileData;
+          childrenRows = Array.isArray(childrenData) ? childrenData : [];
+        } catch (err) {
+          const status = err instanceof HttpError ? err.status : 500;
+          return res.status(status).json({ error: 'Unable to fetch family data', details: err?.details || err?.message || '' });
+        }
+        if (!profileRow) {
+          return res.status(404).json({ error: 'Profil introuvable' });
+        }
+        const childIds = childrenRows.map((child) => child?.id).filter(Boolean).map(String);
+        if (childIds.length) {
+          const inParam = childIds.map((id) => `${encodeURIComponent(id)}`).join(',');
+          try {
+            const updates = await supabaseRequest(
+              `${supaUrl}/rest/v1/child_updates?select=child_id,ai_summary,update_type,update_content,created_at&child_id=in.(${inParam})&order=created_at.desc&limit=40`,
+              { headers }
+            );
+            childUpdates = Array.isArray(updates) ? updates : [];
+          } catch (err) {
+            console.warn('[family-bilan] unable to fetch child_updates', err);
+          }
+        }
+        try {
+          const parentRows = await supabaseRequest(
+            `${supaUrl}/rest/v1/parent_updates?select=update_type,update_content,created_at&profile_id=eq.${encodeURIComponent(profileId)}&order=created_at.desc&limit=20`,
+            { headers }
+          );
+          parentUpdates = Array.isArray(parentRows) ? parentRows : [];
+        } catch (err) {
+          console.warn('[family-bilan] unable to fetch parent_updates', err);
+        }
+        const parentContext = sanitizeParentContextInput(profileRow);
+        const parentContextLines = parentContextToPromptLines(parentContext);
+        const childContextText = formatChildrenForPrompt(childrenRows);
+        const childUpdatesText = formatChildUpdatesForFamilyPrompt(childUpdates, childrenRows);
+        const parentUpdatesText = formatParentUpdatesForPrompt(parentUpdates);
+        const userPromptSections = [
+          `Enfants suivis:\n${childContextText}`,
+          parentContextLines.length
+            ? `Contexte parental actuel:\n${parentContextLines.map((line) => `- ${line}`).join('\n')}`
+            : 'Contexte parental actuel: non précisé.',
+          childUpdatesText.length
+            ? `Évolutions enfant (du plus récent au plus ancien):\n${childUpdatesText.join('\n')}`
+            : 'Évolutions enfant: aucune donnée exploitable.',
+          parentUpdatesText.length
+            ? `Historique parental récent:\n${parentUpdatesText.join('\n')}`
+            : 'Historique parental: aucun changement récent consigné.',
+        ];
+        const system = `Tu es Ped’IA, coach familial bienveillant. À partir des observations enfants et du contexte parental, rédige un bilan structuré en français (400 mots max).
+Structure attendue :
+1. État général de la famille (quelques phrases)
+2. Points marquants pour chaque enfant (liste à puces)
+3. Contexte parental (stress, fatigue, émotions)
+4. Recommandations pratiques (3 actions concrètes adaptées)
+Ton ton est chaleureux, réaliste et encourageant. Mets en lien les difficultés parentales et les observations enfants, et propose des pistes concrètes.`;
+        const openAiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${apiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            model: 'gpt-4o-mini',
+            temperature: 0.35,
+            max_tokens: 900,
+            messages: [
+              { role: 'system', content: system },
+              { role: 'user', content: userPromptSections.join('\n\n') }
+            ]
+          })
+        });
+        if (!openAiResponse.ok) {
+          const errText = await openAiResponse.text();
+          return res.status(502).json({ error: 'OpenAI error', details: errText });
+        }
+        const openAiJson = await openAiResponse.json();
+        const bilan = openAiJson.choices?.[0]?.message?.content?.trim() || '';
+        if (!bilan) {
+          return res.status(502).json({ error: 'Bilan indisponible' });
+        }
+        const nowIso = new Date().toISOString();
+        const payload = [{
+          profile_id: profileId,
+          children_ids: childIds,
+          ai_bilan: bilan.slice(0, 4000),
+          last_generated_at: nowIso,
+        }];
+        try {
+          await supabaseRequest(
+            `${supaUrl}/rest/v1/family_context?on_conflict=profile_id`,
+            {
+              method: 'POST',
+              headers: { ...headers, 'Content-Type': 'application/json', Prefer: 'resolution=merge-duplicates' },
+              body: JSON.stringify(payload),
+            }
+          );
+        } catch (err) {
+          console.warn('[family-bilan] unable to upsert family_context', err);
+        }
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        return res.status(200).send(JSON.stringify({ bilan, lastGeneratedAt: nowIso }));
       }
       case 'child-full-report': {
         const apiKey = process.env.OPENAI_API_KEY;
@@ -367,6 +551,144 @@ function safeChildSummary(child) {
     jalons: child.milestones,
     mesures: child.growth,
   };
+}
+
+function sanitizeParentContextInput(raw) {
+  const ctx = {
+    full_name: '',
+    parent_role: '',
+    marital_status: '',
+    number_of_children: null,
+    parental_employment: '',
+    parental_emotion: '',
+    parental_stress: '',
+    parental_fatigue: '',
+  };
+  if (!raw || typeof raw !== 'object') return ctx;
+  const str = (value) => {
+    if (value == null) return '';
+    const text = String(value).trim();
+    return text.slice(0, 120);
+  };
+  const num = (value) => {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return null;
+    return Math.max(0, Math.min(20, n));
+  };
+  ctx.full_name = str(raw.pseudo || raw.full_name || '');
+  ctx.parent_role = str(raw.role || raw.parent_role || '');
+  ctx.marital_status = str(raw.maritalStatus || raw.marital_status || '');
+  const numberCandidate = raw.numberOfChildren ?? raw.number_of_children;
+  ctx.number_of_children = numberCandidate != null ? num(numberCandidate) : null;
+  ctx.parental_employment = str(raw.parentalEmployment || raw.parental_employment || '');
+  ctx.parental_emotion = str(raw.parentalEmotion || raw.parental_emotion || '');
+  ctx.parental_stress = str(raw.parentalStress || raw.parental_stress || '');
+  ctx.parental_fatigue = str(raw.parentalFatigue || raw.parental_fatigue || '');
+  if (raw.context_parental && typeof raw.context_parental === 'object') {
+    const nested = sanitizeParentContextInput(raw.context_parental);
+    Object.keys(ctx).forEach((key) => {
+      if (!ctx[key]) ctx[key] = nested[key];
+    });
+  }
+  return ctx;
+}
+
+function formatParentContextValue(field, value) {
+  if (field === 'number_of_children') {
+    if (!Number.isFinite(value)) return '';
+    const n = Number(value);
+    return `${n} enfant${n > 1 ? 's' : ''}`;
+  }
+  const labels = PARENT_CONTEXT_VALUE_LABELS[field];
+  if (labels && value != null) {
+    const key = String(value).trim().toLowerCase();
+    if (labels[key]) return labels[key];
+  }
+  if (value == null) return '';
+  const text = String(value).trim();
+  return text;
+}
+
+function parentContextToPromptLines(ctx = {}) {
+  const lines = [];
+  if (ctx.full_name) lines.push(`Pseudo: ${ctx.full_name}`);
+  if (ctx.parent_role) lines.push(`Rôle affiché: ${ctx.parent_role}`);
+  if (ctx.marital_status) lines.push(`Statut marital: ${formatParentContextValue('marital_status', ctx.marital_status)}`);
+  if (Number.isFinite(ctx.number_of_children)) lines.push(`Nombre d’enfants: ${formatParentContextValue('number_of_children', ctx.number_of_children)}`);
+  if (ctx.parental_employment) lines.push(`Situation professionnelle: ${formatParentContextValue('parental_employment', ctx.parental_employment)}`);
+  if (ctx.parental_emotion) lines.push(`État émotionnel: ${formatParentContextValue('parental_emotion', ctx.parental_emotion)}`);
+  if (ctx.parental_stress) lines.push(`Niveau de stress: ${formatParentContextValue('parental_stress', ctx.parental_stress)}`);
+  if (ctx.parental_fatigue) lines.push(`Niveau de fatigue: ${formatParentContextValue('parental_fatigue', ctx.parental_fatigue)}`);
+  return lines;
+}
+
+function formatChildrenForPrompt(children = []) {
+  if (!Array.isArray(children) || !children.length) return 'Aucun enfant enregistré.';
+  return children.map((child, index) => {
+    const parts = [`${index + 1}. ${child?.first_name || 'Enfant'}`];
+    if (child?.sex) parts.push(`sexe: ${child.sex}`);
+    if (child?.dob) parts.push(`naissance: ${formatDateForPrompt(child.dob) || child.dob}`);
+    return parts.join(' – ');
+  }).join('\n');
+}
+
+function formatChildUpdatesForFamilyPrompt(updates = [], children = []) {
+  if (!Array.isArray(updates)) return [];
+  const map = new Map();
+  if (Array.isArray(children)) {
+    children.forEach((child) => {
+      if (!child) return;
+      map.set(String(child.id), child);
+    });
+  }
+  return updates
+    .filter(Boolean)
+    .slice(0, 20)
+    .map((row, index) => {
+      const child = map.get(String(row.child_id));
+      const name = child?.first_name || 'Enfant';
+      const date = formatDateForPrompt(row.created_at);
+      const type = row?.update_type ? String(row.update_type).trim() : '';
+      let summary = typeof row?.ai_summary === 'string' ? row.ai_summary.trim().slice(0, 400) : '';
+      if (!summary) {
+        const parsed = parseUpdateContentForPrompt(row?.update_content);
+        summary = typeof parsed?.summary === 'string' ? parsed.summary.trim().slice(0, 400) : '';
+      }
+      const headerParts = [`${index + 1}. ${name}`];
+      if (date) headerParts.push(`date: ${date}`);
+      if (type) headerParts.push(`type: ${type}`);
+      const header = headerParts.join(' – ');
+      return summary ? `${header}: ${summary}` : header;
+    });
+}
+
+function formatParentUpdatesForPrompt(updates = []) {
+  if (!Array.isArray(updates)) return [];
+  return updates
+    .filter(Boolean)
+    .slice(0, 20)
+    .map((row, index) => {
+      const type = typeof row?.update_type === 'string' ? row.update_type.trim() : '';
+      const label = PARENT_CONTEXT_FIELD_LABELS[type] || (type ? type.replace(/_/g, ' ') : 'Champ');
+      const date = formatDateForPrompt(row?.created_at);
+      let previous = '';
+      let next = '';
+      if (typeof row?.update_content === 'string') {
+        try {
+          const parsed = JSON.parse(row.update_content);
+          if (parsed && typeof parsed === 'object') {
+            previous = formatParentContextValue(type, parsed.previous ?? parsed.avant ?? parsed.old ?? '');
+            next = formatParentContextValue(type, parsed.next ?? parsed.apres ?? parsed.new ?? '');
+          }
+        } catch {}
+      } else if (row?.update_content && typeof row.update_content === 'object') {
+        previous = formatParentContextValue(type, row.update_content.previous);
+        next = formatParentContextValue(type, row.update_content.next);
+      }
+      const changeText = `${previous || 'non renseigné'} → ${next || 'non renseigné'}`;
+      const prefix = `${index + 1}. ${label}`;
+      return date ? `${prefix} (${date}) : ${changeText}` : `${prefix}: ${changeText}`;
+    });
 }
 
 function sanitizeUpdatePayload(value, depth = 0) {

--- a/api/profiles/update-anon.js
+++ b/api/profiles/update-anon.js
@@ -15,6 +15,13 @@ const ALLOWED_UPDATE_FIELDS = new Set([
   'avatar_url',
   'parent_role',
   'show_children_count',
+  'marital_status',
+  'number_of_children',
+  'parental_employment',
+  'parental_emotion',
+  'parental_stress',
+  'parental_fatigue',
+  'context_parental',
 ]);
 
 // Convertit une clé camelCase en snake_case compatible avec la base
@@ -72,7 +79,39 @@ function normalizeField(key, value) {
     if (typeof value === 'boolean') return value;
     return undefined;
   }
+  if (key === 'marital_status' || key === 'parental_employment' || key === 'parental_emotion' || key === 'parental_stress' || key === 'parental_fatigue') {
+    if (value === null) return null;
+    if (typeof value !== 'string') return undefined;
+    return value.trim().slice(0, 120);
+  }
+  if (key === 'number_of_children') {
+    if (value === null) return null;
+    const parsed = parseInt(String(value).trim(), 10);
+    if (!Number.isFinite(parsed)) return undefined;
+    return Math.max(0, Math.min(20, parsed));
+  }
+  if (key === 'context_parental') {
+    if (value === null) return null;
+    if (typeof value !== 'object') return undefined;
+    const ctx = normalizeParentContextObject(value);
+    return ctx;
+  }
   return value;
+}
+
+function normalizeParentContextObject(value) {
+  const ctx = {};
+  const assign = (field, raw) => {
+    const normalized = normalizeField(field, raw);
+    if (normalized !== undefined) ctx[field] = normalized;
+  };
+  assign('marital_status', value?.maritalStatus ?? value?.marital_status ?? null);
+  assign('number_of_children', value?.numberOfChildren ?? value?.number_of_children ?? null);
+  assign('parental_employment', value?.parentalEmployment ?? value?.parental_employment ?? null);
+  assign('parental_emotion', value?.parentalEmotion ?? value?.parental_emotion ?? null);
+  assign('parental_stress', value?.parentalStress ?? value?.parental_stress ?? null);
+  assign('parental_fatigue', value?.parentalFatigue ?? value?.parental_fatigue ?? null);
+  return ctx;
 }
 
 // Récupère le code unique en acceptant plusieurs alias (code, codeUnique, code_unique)

--- a/assets/style.css
+++ b/assets/style.css
@@ -16,6 +16,8 @@
   --muted:rgba(255,255,255,.72); /* muted text: soft white */
   --text:#ffffff;  /* global text color white */
   --text-inverse:#ffffff;
+  --card-text:#1f2933;
+  --card-muted:#6c757d;
   --border:rgba(255,255,255,.18);
   --danger:#ef476f;
   --ok:#2dc07a;
@@ -1680,6 +1682,95 @@ section[data-route="/dashboard"] .chart-card{
 .child-point{stroke:#ffffff; stroke-width:1.5}
 .child-point-latest{animation:breathe 2s ease-in-out infinite; transform-box:fill-box; transform-origin:center}
 @keyframes breathe{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.4);opacity:.5}}
+
+.dashboard-view-toggle{
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+  margin-bottom:16px;
+}
+.dashboard-view-toggle__btn{
+  border:1px solid rgba(30,50,100,.18);
+  background:rgba(255,255,255,.12);
+  color:var(--text);
+  padding:8px 18px;
+  border-radius:999px;
+  font-weight:600;
+  cursor:pointer;
+  transition:background .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+.dashboard-view-toggle__btn:hover{
+  border-color:var(--violet-strong);
+  background:rgba(255,255,255,.18);
+}
+.dashboard-view-toggle__btn.is-active{
+  background:rgba(110,163,255,.28);
+  border-color:var(--violet-strong);
+  box-shadow:0 6px 20px rgba(110,163,255,.35);
+}
+
+.family-context-list{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap:6px;
+}
+.family-context-list li{
+  display:flex;
+  justify-content:space-between;
+  gap:12px;
+  padding:6px 0;
+  border-bottom:1px solid rgba(30,50,100,.1);
+}
+.family-context-list li:last-child{border-bottom:none}
+.family-context-list span{
+  color:var(--card-muted);
+  font-size:.9rem;
+}
+.family-context-list strong{
+  font-weight:600;
+  color:var(--card-text);
+  text-align:right;
+}
+
+.family-children-list{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap:10px;
+}
+.family-children-list li{
+  padding:10px 14px;
+  border:1px solid rgba(30,50,100,.08);
+  border-radius:16px;
+  background:rgba(255,255,255,.75);
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.family-children-list strong{color:var(--card-text); font-size:1rem;}
+.family-children-list span{color:var(--card-muted); font-size:.85rem;}
+
+.family-bilan-card{
+  margin-top:16px;
+  display:grid;
+  gap:12px;
+}
+.family-bilan-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+.family-bilan-text{
+  font-size:.95rem;
+  line-height:1.6;
+  color:var(--card-text);
+}
+.family-bilan-text p{margin:0 0 12px;}
+.family-bilan-text p:last-child{margin-bottom:0;}
 
 /* Landing sections */
 .section{position:relative; padding:32px 0; overflow:visible}

--- a/index.html
+++ b/index.html
@@ -810,6 +810,57 @@
                 <option value="papa">Papa</option>
               </select>
             </label>
+            <h3>Contexte parental</h3>
+            <label>Statut marital
+              <select name="marital_status">
+                <option value="">—</option>
+                <option value="marie">Marié·e / Pacsé·e</option>
+                <option value="couple">En couple</option>
+                <option value="celibataire">Célibataire</option>
+                <option value="separe">Séparé·e / Divorcé·e</option>
+                <option value="veuf">Veuf / Veuve</option>
+                <option value="autre">Autre</option>
+              </select>
+            </label>
+            <label>Nombre d’enfants
+              <input type="number" name="number_of_children" min="0" step="1" inputmode="numeric" />
+            </label>
+            <label>Situation professionnelle
+              <select name="parental_employment">
+                <option value="">—</option>
+                <option value="conge_parental">Congé parental</option>
+                <option value="temps_plein">Temps plein</option>
+                <option value="temps_partiel">Temps partiel</option>
+                <option value="horaires_decales">Horaires décalés / Nuit</option>
+                <option value="sans_emploi">Sans emploi / Entre deux</option>
+                <option value="autre">Autre</option>
+              </select>
+            </label>
+            <label>Niveau de stress
+              <select name="parental_stress">
+                <option value="">—</option>
+                <option value="faible">Faible</option>
+                <option value="modere">Modéré</option>
+                <option value="eleve">Élevé</option>
+              </select>
+            </label>
+            <label>Niveau de fatigue
+              <select name="parental_fatigue">
+                <option value="">—</option>
+                <option value="faible">Faible</option>
+                <option value="modere">Modérée</option>
+                <option value="eleve">Élevée</option>
+              </select>
+            </label>
+            <label>État émotionnel
+              <select name="parental_emotion">
+                <option value="">—</option>
+                <option value="positif">Positif / serein</option>
+                <option value="neutre">Neutre</option>
+                <option value="fragile">Fragile / sensible</option>
+                <option value="anxieux">Anxieux / stressé</option>
+              </select>
+            </label>
             <h3>Confidentialité</h3>
             <label class="switch">
               <input type="checkbox" name="showStats" />


### PR DESCRIPTION
## Summary
- queue and reuse family bilan regenerations from the dashboard so the switch and refresh button stay in sync while avoiding duplicate API calls
- wire the AI worker to blend parent context into child comments and persist a generated family bilan in Supabase
- normalize the new parental context payload in the anonymous profile updater and update the family view styling for readability

## Testing
- node --check assets/app.js
- node --check api/ai.js
- node --check api/profiles/update-anon.js

------
https://chatgpt.com/codex/tasks/task_e_68d1cfa06088832185837f7b4f8d30df