### PR TITLE
Fix anon family API routing and sanitize child payloads

### DIFF
--- a/api/anon/family.js
+++ b/api/anon/family.js
@@ -1,0 +1,36 @@
+import { processAnonFamilyRequest } from '../../lib/anon-family.js';
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    return res.status(204).end();
+  }
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST,OPTIONS');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+  try {
+    let bodyRaw = '';
+    for await (const chunk of req) bodyRaw += chunk;
+    let payload = {};
+    if (bodyRaw) {
+      try {
+        payload = JSON.parse(bodyRaw);
+      } catch (parseErr) {
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        return res.status(400).json({ error: 'Format invalide', details: 'Invalid JSON body' });
+      }
+    }
+    const result = await processAnonFamilyRequest(payload);
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    const status = err && Number.isInteger(err.status) ? err.status : 500;
+    const details = String(err?.details || err?.message || err);
+    console.error('[api/anon/family] handler error', { status, details, error: err });
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    return res.status(status).json({ error: 'Service indisponible', details });
+  }
+}

--- a/lib/anon-children.js
+++ b/lib/anon-children.js
@@ -292,6 +292,13 @@ async function generateAiCommentaire(updateType, updateText, parentComment, prev
 // Normalise une chaîne en limitant sa longueur et en gérant éventuellement les valeurs nulles
 function normalizeString(raw, max = 500, { allowNull = false } = {}) {
   if (raw == null) return allowNull ? null : '';
+  if (typeof raw === 'object') {
+    if (raw instanceof Date) {
+      const iso = raw.toISOString();
+      return allowNull ? iso : iso.slice(0, max);
+    }
+    return allowNull ? null : '';
+  }
   const str = String(raw).trim();
   if (!str && allowNull) return null;
   return str.slice(0, max);
@@ -313,6 +320,61 @@ function normalizeBoolean(raw) {
 function normalizeMilestones(raw) {
   if (!Array.isArray(raw)) return [];
   return raw.slice(0, 120).map(v => !!v);
+}
+
+function parseInteger(value) {
+  if (value == null) return null;
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? value : null;
+  }
+  const str = String(value).trim();
+  if (!str) return null;
+  if (!/^[-+]?\d+$/.test(str)) return null;
+  const parsed = Number.parseInt(str, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeChildId(raw) {
+  if (raw == null) throw new HttpError(400, 'Paramètre manquant: child_id');
+  const str = typeof raw === 'string' ? raw.trim() : String(raw).trim();
+  if (!str) throw new HttpError(400, 'Paramètre manquant: child_id');
+  const parsed = parseInteger(str);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new HttpError(400, 'Format invalide: child_id');
+  }
+  return String(parsed);
+}
+
+function extractSupabaseDetail(err) {
+  const details = err?.details;
+  if (!details) return '';
+  if (typeof details === 'string') return details;
+  if (typeof details === 'object') {
+    if (typeof details.message === 'string') return details.message;
+    if (typeof details.error_description === 'string') return details.error_description;
+    if (typeof details.error === 'string') return details.error;
+  }
+  return '';
+}
+
+function formatHttpErrorMessage(err, { fallback = 'Service indisponible' } = {}) {
+  if (!(err instanceof HttpError)) return fallback;
+  if (err.message && err.message !== 'Supabase error') return err.message;
+  if (err.status === 404) return 'Child not found';
+  if (err.status === 400 || err.status === 422) return 'Format invalide';
+  if (err.status === 401 || err.status === 403) return 'Accès refusé';
+  return fallback;
+}
+
+function buildHttpErrorResponse(err, { fallback = 'Service indisponible' } = {}) {
+  if (err instanceof HttpError) {
+    const status = err.status || 500;
+    const message = formatHttpErrorMessage(err, { fallback });
+    const detail = extractSupabaseDetail(err) || err.details || err.message;
+    return { status, body: { error: message, details: detail } };
+  }
+  const detail = err && typeof err === 'object' ? (err.message || JSON.stringify(err)) : String(err);
+  return { status: 500, body: { error: fallback, details: detail } };
 }
 
 /**
@@ -472,16 +534,16 @@ async function fetchAnonProfile(supaUrl, serviceKey, code) {
     { headers }
   );
   const row = Array.isArray(data) ? data[0] : data;
-  if (!row) throw new HttpError(404, 'Code not found');
-  if (row.user_id) throw new HttpError(403, 'Not an anonymous profile');
+  if (!row || row.user_id) throw new HttpError(400, 'Code non reconnu');
   return row;
 }
 
 // Récupère un enfant précis tout en validant son appartenance au profil anonyme
 async function fetchChild(supaUrl, serviceKey, childId) {
+  const safeId = normalizeChildId(childId);
   const headers = { 'apikey': serviceKey, 'Authorization': `Bearer ${serviceKey}` };
   const data = await supabaseRequest(
-    `${supaUrl}/rest/v1/children?select=*&id=eq.${encodeURIComponent(childId)}&limit=1`,
+    `${supaUrl}/rest/v1/children?select=*&id=eq.${encodeURIComponent(safeId)}&limit=1`,
     { headers }
   );
   const row = Array.isArray(data) ? data[0] : data;
@@ -492,7 +554,9 @@ async function fetchChild(supaUrl, serviceKey, childId) {
 // Ajoute l’identifiant enfant à chaque enregistrement associé (mesures, sommeil, dents)
 function withChildId(records, childId) {
   if (!Array.isArray(records) || !records.length) return [];
-  return records.map(r => ({ ...r, child_id: childId }));
+  const parsed = parseInteger(childId);
+  if (!Number.isFinite(parsed)) throw new HttpError(400, 'Format invalide: child_id');
+  return records.map(r => ({ ...r, child_id: parsed }));
 }
 
 async function hasPrimaryChild(supaUrl, headers, profileId) {
@@ -516,9 +580,9 @@ async function hasPrimaryChild(supaUrl, headers, profileId) {
 export async function processAnonChildrenRequest(body) {
   try {
     const action = String(body?.action || '').trim();
-    if (!action) throw new HttpError(400, 'action required');
+    if (!action) throw new HttpError(400, 'Paramètre manquant: action');
     const code = normalizeCode(body.code || body.code_unique);
-    if (!code) throw new HttpError(400, 'code required');
+    if (!code) throw new HttpError(400, 'Code non reconnu');
     const payload = getActionPayload(body);
     const { supaUrl, serviceKey } = getServiceConfig();
     const headers = { 'apikey': serviceKey, 'Authorization': `Bearer ${serviceKey}` };
@@ -534,8 +598,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'get') {
-      const childId = normalizeString(payload.childId ?? payload.child_id ?? payload.id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = normalizeChildId(payload.childId ?? payload.child_id ?? payload.id);
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Forbidden');
       const [ms, sleep, teeth] = await Promise.all([
@@ -566,11 +629,11 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'growth-status') {
-      const childId = normalizeString(payload.childId ?? payload.child_id ?? payload.id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = normalizeChildId(payload.childId ?? payload.child_id ?? payload.id);
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Forbidden');
-      const limit = Math.max(1, Math.min(20, Number(payload.limit) || 20));
+      const limitCandidate = parseInteger(payload.limit);
+      const limit = limitCandidate == null ? 20 : Math.max(1, Math.min(20, limitCandidate));
       const baseUrl = `${supaUrl}/rest/v1/child_growth_with_status?select=*&child_id=eq.${encodeURIComponent(childId)}&limit=${limit}`;
       const attempts = [
         '&order=measured_at.desc.nullslast',
@@ -603,7 +666,7 @@ export async function processAnonChildrenRequest(body) {
     if (action === 'create') {
       const childPayload = sanitizeChildInsert(payload.child, profileId);
       if (!childPayload.first_name || !childPayload.dob || !childPayload.sex) {
-        throw new HttpError(400, 'Invalid child payload');
+        throw new HttpError(400, 'Format invalide: child');
       }
       const alreadyHasPrimary = await hasPrimaryChild(supaUrl, headers, profileId);
       childPayload.is_primary = !alreadyHasPrimary;
@@ -655,8 +718,9 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'update') {
-      const childId = normalizeString(payload.childId ?? payload.child_id ?? payload.id ?? (payload.child?.id ?? ''), 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = normalizeChildId(
+        payload.childId ?? payload.child_id ?? payload.id ?? (payload.child?.id ?? null)
+      );
       const existing = await fetchChild(supaUrl, serviceKey, childId);
       if (existing.user_id !== profileId) throw new HttpError(403, 'Forbidden');
       const updatePayload = sanitizeChildUpdate(payload.child);
@@ -709,8 +773,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'delete') {
-      const childId = normalizeString(payload.childId ?? payload.child_id ?? payload.id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = normalizeChildId(payload.childId ?? payload.child_id ?? payload.id);
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Forbidden');
       await supabaseRequest(
@@ -724,8 +787,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'set-primary') {
-      const childId = normalizeString(payload.childId ?? payload.child_id ?? payload.id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = normalizeChildId(payload.childId ?? payload.child_id ?? payload.id);
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Forbidden');
       await supabaseRequest(
@@ -748,8 +810,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'log-update') {
-      const childId = normalizeString(payload.childId ?? payload.child_id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = normalizeChildId(payload.childId ?? payload.child_id ?? payload.id);
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Forbidden');
       const updateType = normalizeString(payload.updateType ?? payload.type ?? '', 64);
@@ -805,8 +866,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'list-updates') {
-      const childId = normalizeString(payload.childId ?? payload.child_id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = normalizeChildId(payload.childId ?? payload.child_id ?? payload.id);
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Forbidden');
       const updates = await supabaseRequest(
@@ -817,8 +877,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'add-growth') {
-      const childId = normalizeString(payload.childId ?? payload.child_id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = normalizeChildId(payload.childId ?? payload.child_id ?? payload.id);
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Forbidden');
       const measurements = withChildId(buildMeasurementRecords(payload.growthMeasurements ?? payload.measurements), childId);
@@ -857,12 +916,12 @@ export async function processAnonChildrenRequest(body) {
       return { status: 200, body: { success: true } };
     }
 
-    throw new HttpError(400, 'Unknown action');
+    throw new HttpError(400, 'Action inconnue');
   } catch (err) {
-    if (err instanceof HttpError) {
-      return { status: err.status || 500, body: { error: err.message, details: err.details } };
+    if (!(err instanceof HttpError) || (err.status && err.status >= 500)) {
+      console.error('[anon-children] request error', err);
     }
-    return { status: 500, body: { error: 'Server error', details: String(err && err.message ? err.message : err) } };
+    return buildHttpErrorResponse(err);
   }
 }
 
@@ -876,8 +935,12 @@ export {
   getActionPayload,
   normalizeString,
   normalizeCode,
+  normalizeChildId,
+  parseInteger,
   supabaseRequest,
   fetchGrowthDataForAnonPrompt,
   formatGrowthSectionForAnonPrompt,
   formatDateForPrompt,
+  buildHttpErrorResponse,
+  formatHttpErrorMessage,
 };

--- a/lib/anon-family.js
+++ b/lib/anon-family.js
@@ -4,8 +4,10 @@ import {
   getServiceConfig,
   getActionPayload,
   normalizeCode,
-  normalizeString,
+  normalizeChildId,
+  parseInteger,
   supabaseRequest,
+  buildHttpErrorResponse,
 } from './anon-children.js';
 import { buildProfileResponse } from './anon-profile.js';
 import {
@@ -23,8 +25,9 @@ async function fetchChildrenForProfile(supaUrl, headers, profileId) {
 }
 
 async function fetchChildForProfile(supaUrl, headers, profileId, childId) {
+  const safeChildId = normalizeChildId(childId);
   const rows = await supabaseRequest(
-    `${supaUrl}/rest/v1/children?select=*&id=eq.${encodeURIComponent(childId)}&user_id=eq.${encodeURIComponent(profileId)}&limit=1`,
+    `${supaUrl}/rest/v1/children?select=*&id=eq.${encodeURIComponent(safeChildId)}&user_id=eq.${encodeURIComponent(profileId)}&limit=1`,
     { headers }
   );
   const row = Array.isArray(rows) ? rows[0] : rows;
@@ -36,22 +39,25 @@ async function fetchChildForProfile(supaUrl, headers, profileId, childId) {
 export async function processAnonFamilyRequest(body) {
   try {
     const action = String(body?.action || '').trim();
-    if (!action) throw new HttpError(400, 'action required');
+    if (!action) throw new HttpError(400, 'Paramètre manquant: action');
     const code = normalizeCode(body?.code || body?.code_unique);
-    if (!code) throw new HttpError(400, 'code required');
+    if (!code) throw new HttpError(400, 'Code non reconnu');
     const payload = getActionPayload(body);
 
     const { supaUrl, serviceKey } = getServiceConfig();
     const headers = { 'apikey': serviceKey, 'Authorization': `Bearer ${serviceKey}` };
     const profile = await fetchAnonProfile(supaUrl, serviceKey, code);
     const profileId = profile?.id;
-    if (!profileId) throw new HttpError(404, 'Profile not found');
+    if (!profileId) throw new HttpError(400, 'Code non reconnu');
 
     if (action === 'overview') {
       const includeChildren = payload?.includeChildren !== false;
       const includeParentUpdates = payload?.includeParentUpdates !== false;
       const includeFamilyContext = payload?.includeFamilyContext !== false;
-      const updatesLimit = payload?.updatesLimit ?? payload?.limit ?? 12;
+      const updatesLimitCandidate = parseInteger(payload?.updatesLimit ?? payload?.limit);
+      const updatesLimit = updatesLimitCandidate == null
+        ? 12
+        : Math.max(1, Math.min(50, updatesLimitCandidate));
 
       const tasks = [];
       tasks.push(fetchProfileDetails(supaUrl, headers, profileId).catch(() => null));
@@ -84,10 +90,12 @@ export async function processAnonFamilyRequest(body) {
     }
 
     if (action === 'growth-status') {
-      const childId = normalizeString(payload?.childId ?? payload?.child_id ?? payload?.id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = normalizeChildId(payload?.childId ?? payload?.child_id ?? payload?.id);
       await fetchChildForProfile(supaUrl, headers, profileId, childId);
-      const safeLimit = Math.max(1, Math.min(50, Number(payload?.limit) || 20));
+      const limitCandidate = parseInteger(payload?.limit);
+      const safeLimit = limitCandidate == null
+        ? 20
+        : Math.max(1, Math.min(50, limitCandidate));
       const baseUrl = `${supaUrl}/rest/v1/child_growth_with_status?select=*&child_id=eq.${encodeURIComponent(childId)}&limit=${safeLimit}`;
       const attempts = [
         '&order=measured_at.desc.nullslast',
@@ -117,11 +125,11 @@ export async function processAnonFamilyRequest(body) {
       return { status: 200, body: bodyPayload };
     }
 
-    throw new HttpError(400, 'Unknown action');
+    throw new HttpError(400, 'Action inconnue');
   } catch (err) {
-    if (err instanceof HttpError) {
-      return { status: err.status || 500, body: { error: err.message, details: err.details } };
+    if (!(err instanceof HttpError) || (err.status && err.status >= 500)) {
+      console.error('[anon-family] request error', err);
     }
-    return { status: 500, body: { error: 'Server error', details: String(err?.message || err) } };
+    return buildHttpErrorResponse(err);
   }
 }


### PR DESCRIPTION
## Summary
- add dedicated `/api/anon/family` endpoint that proxies anon family actions with consistent error handling
- harden anon children service to normalize identifiers and translate Supabase errors into user friendly messages
- sanitize anonymous child/family front-end payloads and surface clearer console errors before hitting the backend

## Testing
- node -e "import('./lib/anon-children.js').then(()=>console.log('anon-children loaded'))"
- node -e "import('./lib/anon-family.js').then(()=>console.log('anon-family loaded'))"

------
https://chatgpt.com/codex/tasks/task_e_68d359bc1f948321b716a2803c780e62