### PR TITLE
Add debug logs for anonymous API requests

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -961,6 +961,12 @@ const TIMELINE_MILESTONES = [
     const code = (activeProfile.code_unique || '').toString().trim().toUpperCase();
     if (!code) throw new Error('Code unique manquant');
     const body = { action, code, ...payload };
+    if (typeof body.code === 'string') {
+      body.code = body.code.trim().toUpperCase();
+    }
+    if (!body.code) {
+      console.warn('Anon request without code:', body);
+    }
     const response = await fetch('/api/anon/children', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -972,6 +978,7 @@ const TIMELINE_MILESTONES = [
       try { json = JSON.parse(text); } catch {}
     }
     if (!response.ok) {
+      console.error('Anon response:', response.status, text);
       const err = new Error(json?.error || 'Service indisponible');
       if (json?.details) err.details = json.details;
       throw err;
@@ -984,6 +991,12 @@ const TIMELINE_MILESTONES = [
     const code = (activeProfile.code_unique || '').toString().trim().toUpperCase();
     if (!code) throw new Error('Code unique manquant');
     const body = { action, code, ...payload };
+    if (typeof body.code === 'string') {
+      body.code = body.code.trim().toUpperCase();
+    }
+    if (!body.code) {
+      console.warn('Anon request without code:', body);
+    }
     const response = await fetch('/api/anon/parent-updates', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -995,6 +1008,7 @@ const TIMELINE_MILESTONES = [
       try { json = JSON.parse(text); } catch {}
     }
     if (!response.ok) {
+      console.error('Anon response:', response.status, text);
       const err = new Error(json?.error || 'Service indisponible');
       if (json?.details) err.details = json.details;
       throw err;
@@ -1007,6 +1021,12 @@ const TIMELINE_MILESTONES = [
     const code = (activeProfile.code_unique || '').toString().trim().toUpperCase();
     if (!code) throw new Error('Code unique manquant');
     const body = { action, code, ...payload };
+    if (typeof body.code === 'string') {
+      body.code = body.code.trim().toUpperCase();
+    }
+    if (!body.code) {
+      console.warn('Anon request without code:', body);
+    }
     const response = await fetch('/api/anon/family', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1018,6 +1038,7 @@ const TIMELINE_MILESTONES = [
       try { json = JSON.parse(text); } catch {}
     }
     if (!response.ok) {
+      console.error('Anon response:', response.status, text);
       const err = new Error(json?.error || 'Service indisponible');
       if (json?.details) err.details = json.details;
       throw err;
@@ -1058,6 +1079,12 @@ const TIMELINE_MILESTONES = [
     const code = (activeProfile.code_unique || '').toString().trim().toUpperCase();
     if (!code) throw new Error('Code unique manquant');
     const body = { action, code, ...payload };
+    if (typeof body.code === 'string') {
+      body.code = body.code.trim().toUpperCase();
+    }
+    if (!body.code) {
+      console.warn('Anon request without code:', body);
+    }
     const response = await fetch('/api/anon/community', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1069,12 +1096,20 @@ const TIMELINE_MILESTONES = [
       try { json = JSON.parse(text); } catch {}
     }
     if (!response.ok) {
+      console.error('Anon response:', response.status, text);
       const err = new Error(json?.error || 'Service indisponible');
       if (json?.details) err.details = json.details;
       throw err;
     }
     return json || {};
   }
+
+  anonChildRequest.__anonEndpoint = '/api/anon/children';
+  anonChildRequest.__expectsCode = true;
+  anonParentRequest.__anonEndpoint = '/api/anon/parent-updates';
+  anonParentRequest.__expectsCode = true;
+  anonFamilyRequest.__anonEndpoint = '/api/anon/family';
+  anonFamilyRequest.__expectsCode = true;
 
   dataProxy = createDataProxy({
     getActiveProfile: () => activeProfile,

--- a/assets/data-proxy.js
+++ b/assets/data-proxy.js
@@ -61,7 +61,38 @@ export function createDataProxy({
         if (typeof anonHandler !== 'function') {
           throw new Error(DEFAULT_ERROR_MESSAGES.missingAnonHandler);
         }
-        return anonHandler(action, payload);
+        const endpoint =
+          typeof anonHandler.__anonEndpoint === 'string'
+            ? anonHandler.__anonEndpoint
+            : '(unknown anon endpoint)';
+        const expectsCode = anonHandler.__expectsCode !== false;
+        const basePayload = payload && typeof payload === 'object' ? { ...payload } : {};
+        if (expectsCode) {
+          const existingCode = typeof basePayload.code === 'string' ? basePayload.code.trim() : basePayload.code;
+          if (!existingCode) {
+            const profile = typeof getProfile === 'function' ? getProfile() : null;
+            const rawCode =
+              (profile && (profile.code_unique || profile.codeUnique))
+                ? profile.code_unique || profile.codeUnique
+                : '';
+            const normalizedCode =
+              typeof rawCode === 'string'
+                ? rawCode.trim().toUpperCase()
+                : rawCode != null
+                ? String(rawCode).trim().toUpperCase()
+                : '';
+            if (normalizedCode) {
+              basePayload.code = normalizedCode;
+            } else {
+              console.warn('Anon request without code:', { action, ...basePayload });
+            }
+          } else if (typeof existingCode === 'string') {
+            basePayload.code = existingCode.trim().toUpperCase();
+          }
+        }
+        const logPayload = basePayload && typeof basePayload === 'object' ? { action, ...basePayload } : { action };
+        console.log('Anon request:', endpoint, logPayload);
+        return anonHandler(action, basePayload);
       },
     };
   };


### PR DESCRIPTION
## Summary
- add instrumentation in the data proxy to log outgoing anonymous requests and surface missing codes
- ensure anonymous fetch helpers warn on missing codes and log non-ok responses for easier debugging
- expose endpoint metadata to the proxy so logs include the target URL

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d37b1dc5dc8321a5be8f414b179ebd