### PR TITLE
Normalize child request payloads before Supabase operations

### DIFF
--- a/assets/data-proxy.js
+++ b/assets/data-proxy.js
@@ -1,3 +1,144 @@
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const CHILD_ACTIONS_REQUIRING_ID = new Set(['get', 'growth-status', 'update', 'delete', 'set-primary', 'log-update', 'list-updates', 'add-growth']);
+
+function normalizeSexValue(raw) {
+  if (raw == null || raw === '') return null;
+  if (typeof raw === 'number' && Number.isInteger(raw)) {
+    if (raw === 0 || raw === 1) return raw;
+    return null;
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    const normalized = trimmed
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '');
+    if (['0', 'f', 'fille', 'girl', 'femme', 'female', 'feminin'].includes(normalized)) return 0;
+    if (['1', 'g', 'm', 'garcon', 'garconne', 'boy', 'masculin', 'male'].includes(normalized)) return 1;
+  }
+  return null;
+}
+
+function normalizeDobValue(raw) {
+  if (raw == null) return null;
+  if (raw instanceof Date && !Number.isNaN(raw.getTime())) {
+    return raw.toISOString().split('T')[0];
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    const match = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) return null;
+    const date = new Date(trimmed);
+    if (Number.isNaN(date.getTime())) return null;
+    const iso = date.toISOString().split('T')[0];
+    if (iso !== `${match[1]}-${match[2]}-${match[3]}`) return null;
+    return iso;
+  }
+  return null;
+}
+
+function normalizeChildIdValue(value) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return '';
+    return UUID_REGEX.test(trimmed) ? trimmed : '';
+  }
+  if (value == null) return '';
+  return normalizeChildIdValue(String(value));
+}
+
+export function assertValidChildId(value) {
+  const normalized = normalizeChildIdValue(value);
+  if (!normalized) {
+    throw new Error('child_id manquant ou invalide');
+  }
+  return normalized;
+}
+
+export function normalizeChildPayloadForSupabase(child = {}) {
+  const payload = child && typeof child === 'object' ? { ...child } : {};
+  if (Object.prototype.hasOwnProperty.call(payload, 'sex')) {
+    const normalizedSex = normalizeSexValue(payload.sex);
+    if (normalizedSex == null) {
+      delete payload.sex;
+    } else {
+      payload.sex = normalizedSex;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, 'dob')) {
+    const normalizedDob = normalizeDobValue(payload.dob);
+    if (normalizedDob) {
+      payload.dob = normalizedDob;
+    } else {
+      delete payload.dob;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, 'child_id')) {
+    const normalizedId = normalizeChildIdValue(payload.child_id);
+    if (normalizedId) {
+      payload.child_id = normalizedId;
+    } else {
+      delete payload.child_id;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, 'childId')) {
+    const normalizedId = normalizeChildIdValue(payload.childId);
+    if (normalizedId) {
+      payload.child_id = normalizedId;
+    }
+    delete payload.childId;
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, 'id')) {
+    const normalizedId = normalizeChildIdValue(payload.id);
+    if (normalizedId) {
+      payload.id = normalizedId;
+    } else {
+      delete payload.id;
+    }
+  }
+  return payload;
+}
+
+export function normalizeAnonChildPayload(action, payload = {}) {
+  const base = payload && typeof payload === 'object' ? { ...payload } : {};
+  if (base.child && typeof base.child === 'object') {
+    base.child = normalizeChildPayloadForSupabase(base.child);
+  }
+  let candidate = base.child_id ?? base.childId ?? base.id ?? (base.child && base.child.id);
+  if (candidate != null) {
+    const normalized = normalizeChildIdValue(candidate);
+    if (normalized) {
+      base.child_id = normalized;
+    } else if (CHILD_ACTIONS_REQUIRING_ID.has(action)) {
+      throw new Error('child_id manquant ou invalide');
+    } else {
+      delete base.child_id;
+    }
+  } else if (CHILD_ACTIONS_REQUIRING_ID.has(action)) {
+    throw new Error('child_id manquant ou invalide');
+  }
+  if (base.child && typeof base.child === 'object' && Object.prototype.hasOwnProperty.call(base.child, 'id')) {
+    const normalizedChildId = normalizeChildIdValue(base.child.id);
+    if (normalizedChildId) {
+      base.child.id = normalizedChildId;
+    } else {
+      delete base.child.id;
+    }
+  }
+  if ('childId' in base) delete base.childId;
+  if ('id' in base && (base.id === candidate || typeof base.id === 'string')) {
+    const normalizedInlineId = normalizeChildIdValue(base.id);
+    if (normalizedInlineId) {
+      base.id = normalizedInlineId;
+    } else {
+      delete base.id;
+    }
+  }
+  return base;
+}
+
 const DEFAULT_ERROR_MESSAGES = {
   missingSupabase: 'Supabase client unavailable',
   missingAnonHandler: 'Anonymous route unavailable',
@@ -66,7 +207,7 @@ export function createDataProxy({
             ? anonHandler.__anonEndpoint
             : '(unknown anon endpoint)';
         const expectsCode = anonHandler.__expectsCode !== false;
-        const basePayload = payload && typeof payload === 'object' ? { ...payload } : {};
+        let basePayload = payload && typeof payload === 'object' ? { ...payload } : {};
         if (expectsCode) {
           const existingCode = typeof basePayload.code === 'string' ? basePayload.code.trim() : basePayload.code;
           if (!existingCode) {
@@ -89,6 +230,17 @@ export function createDataProxy({
           } else if (typeof existingCode === 'string') {
             basePayload.code = existingCode.trim().toUpperCase();
           }
+        }
+        if (typeof anonHandler.__normalizePayload === 'function') {
+          const normalized = anonHandler.__normalizePayload(action, basePayload);
+          if (normalized && typeof normalized === 'object') {
+            basePayload = normalized;
+          } else {
+            basePayload = {};
+          }
+        }
+        if (expectsCode && typeof basePayload.code === 'string') {
+          basePayload.code = basePayload.code.trim().toUpperCase();
         }
         const logPayload = basePayload && typeof basePayload === 'object' ? { action, ...basePayload } : { action };
         console.log('Anon request:', endpoint, logPayload);

--- a/lib/anon-children.js
+++ b/lib/anon-children.js
@@ -10,6 +10,7 @@ const CHILD_TEXT_FIELDS = [
 ];
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Erreur HTTP enrichie utilisée pour faire remonter proprement les statuts Supabase
 class HttpError extends Error {
@@ -287,6 +288,65 @@ function normalizeString(raw, max = 500, { allowNull = false } = {}) {
   return str.slice(0, max);
 }
 
+function normalizeSex(raw) {
+  if (raw == null || raw === '') return null;
+  if (typeof raw === 'number' && Number.isInteger(raw)) {
+    if (raw === 0 || raw === 1) return raw;
+    return null;
+  }
+  if (typeof raw === 'string') {
+    const stripped = raw.trim();
+    if (!stripped) return null;
+    const normalized = stripped
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '');
+    if (['0', 'f', 'fille', 'girl', 'femme', 'female', 'feminin'].includes(normalized)) return 0;
+    if (['1', 'g', 'm', 'garcon', 'garconne', 'boy', 'masculin', 'male'].includes(normalized)) return 1;
+  }
+  return null;
+}
+
+function normalizeDob(raw) {
+  if (raw == null) return null;
+  if (raw instanceof Date && !Number.isNaN(raw.getTime())) {
+    return raw.toISOString().split('T')[0];
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    const match = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) return null;
+    const date = new Date(trimmed);
+    if (Number.isNaN(date.getTime())) return null;
+    const iso = date.toISOString().split('T')[0];
+    if (iso !== `${match[1]}-${match[2]}-${match[3]}`) return null;
+    return iso;
+  }
+  return null;
+}
+
+function normalizeUuid(value) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return '';
+    return UUID_REGEX.test(trimmed) ? trimmed : '';
+  }
+  if (value == null) return '';
+  return normalizeUuid(String(value));
+}
+
+function resolveChildId(source, { required = false } = {}) {
+  const candidate = source && typeof source === 'object'
+    ? source.child_id ?? source.childId ?? source.id ?? (source.child && source.child.id)
+    : source;
+  const normalized = normalizeUuid(candidate || '');
+  if (!normalized && required) {
+    throw new HttpError(400, 'child_id manquant ou invalide');
+  }
+  return normalized;
+}
+
 // Convertit différentes représentations (nombre, booléen, texte) en booléen strict
 function normalizeBoolean(raw) {
   if (typeof raw === 'boolean') return raw;
@@ -314,8 +374,6 @@ function sanitizeChildInsert(raw, profileId) {
   const payload = {
     user_id: profileId,
     first_name: normalizeString(raw.first_name ?? raw.firstName ?? '', 120),
-    sex: normalizeString(raw.sex ?? '', 20),
-    dob: normalizeString(raw.dob ?? '', 32),
     photo_url: normalizeString(raw.photo_url ?? raw.photoUrl ?? raw.photo ?? '', 2048, { allowNull: true }),
     feeding_type: normalizeString(raw.feeding_type ?? raw.feedingType ?? '', 120),
     eating_style: normalizeString(raw.eating_style ?? raw.eatingStyle ?? '', 120),
@@ -324,6 +382,10 @@ function sanitizeChildInsert(raw, profileId) {
     milestones: normalizeMilestones(raw.milestones),
     is_primary: !!raw.is_primary,
   };
+  const sexValue = normalizeSex(raw.sex ?? raw.gender);
+  if (sexValue != null) payload.sex = sexValue;
+  const dobValue = normalizeDob(raw.dob ?? raw.birthdate ?? raw.birth_date);
+  if (dobValue) payload.dob = dobValue;
   CHILD_TEXT_FIELDS.forEach(key => {
     const altKey = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
     payload[key] = normalizeString(raw[key] ?? raw[altKey] ?? '', 500);
@@ -342,10 +404,12 @@ function sanitizeChildUpdate(raw) {
     payload.first_name = normalizeString(raw.first_name ?? raw.firstName ?? '', 120);
   }
   if (Object.prototype.hasOwnProperty.call(raw, 'sex')) {
-    payload.sex = normalizeString(raw.sex ?? '', 20);
+    const sexValue = normalizeSex(raw.sex);
+    if (sexValue != null) payload.sex = sexValue;
   }
   if (Object.prototype.hasOwnProperty.call(raw, 'dob')) {
-    payload.dob = normalizeString(raw.dob ?? '', 32);
+    const dobValue = normalizeDob(raw.dob);
+    if (dobValue) payload.dob = dobValue;
   }
   if (Object.prototype.hasOwnProperty.call(raw, 'photo_url') || Object.prototype.hasOwnProperty.call(raw, 'photoUrl') || Object.prototype.hasOwnProperty.call(raw, 'photo')) {
     payload.photo_url = normalizeString(raw.photo_url ?? raw.photoUrl ?? raw.photo ?? '', 2048, { allowNull: true });
@@ -523,8 +587,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'get') {
-      const childId = normalizeString(body.childId ?? body.child_id ?? body.id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = resolveChildId(body, { required: true });
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Accès non autorisé');
       const [ms, sleep, teeth] = await Promise.all([
@@ -555,8 +618,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'growth-status') {
-      const childId = normalizeString(body.childId ?? body.child_id ?? body.id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = resolveChildId(body, { required: true });
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Accès non autorisé');
       const limit = Math.max(1, Math.min(20, Number(body.limit) || 20));
@@ -591,7 +653,7 @@ export async function processAnonChildrenRequest(body) {
 
     if (action === 'create') {
       const childPayload = sanitizeChildInsert(body.child, profileId);
-      if (!childPayload.first_name || !childPayload.dob || !childPayload.sex) {
+      if (!childPayload.first_name || typeof childPayload.dob !== 'string' || !Number.isInteger(childPayload.sex)) {
         throw new HttpError(400, 'Invalid child payload');
       }
       const alreadyHasPrimary = await hasPrimaryChild(supaUrl, headers, profileId);
@@ -644,8 +706,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'update') {
-      const childId = normalizeString(body.childId ?? body.child_id ?? body.id ?? (body.child?.id ?? ''), 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = resolveChildId(body, { required: true });
       const existing = await fetchChild(supaUrl, serviceKey, childId);
       if (existing.user_id !== profileId) throw new HttpError(403, 'Accès non autorisé');
       const updatePayload = sanitizeChildUpdate(body.child);
@@ -698,8 +759,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'delete') {
-      const childId = normalizeString(body.childId ?? body.child_id ?? body.id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = resolveChildId(body, { required: true });
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Accès non autorisé');
       await supabaseRequest(
@@ -713,8 +773,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'set-primary') {
-      const childId = normalizeString(body.childId ?? body.child_id ?? body.id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = resolveChildId(body, { required: true });
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Accès non autorisé');
       await supabaseRequest(
@@ -737,8 +796,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'log-update') {
-      const childId = normalizeString(body.childId ?? body.child_id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = resolveChildId(body, { required: true });
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Accès non autorisé');
       const updateType = normalizeString(body.updateType ?? body.type ?? '', 64);
@@ -794,8 +852,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'list-updates') {
-      const childId = normalizeString(body.childId ?? body.child_id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = resolveChildId(body, { required: true });
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Accès non autorisé');
       const updates = await supabaseRequest(
@@ -806,8 +863,7 @@ export async function processAnonChildrenRequest(body) {
     }
 
     if (action === 'add-growth') {
-      const childId = normalizeString(body.childId ?? body.child_id ?? '', 128);
-      if (!childId) throw new HttpError(400, 'child_id required');
+      const childId = resolveChildId(body, { required: true });
       const child = await fetchChild(supaUrl, serviceKey, childId);
       if (child.user_id !== profileId) throw new HttpError(403, 'Forbidden');
       const measurements = withChildId(buildMeasurementRecords(body.growthMeasurements ?? body.measurements), childId);


### PR DESCRIPTION
## Summary
- add reusable helpers in the anonymous children API to normalize sex, birth date and child_id fields before persisting
- teach the data proxy to sanitize anonymous request payloads and share the normalization utilities with the front-end
- update front-end create/update/delete flows to validate child IDs, reuse normalized payloads and avoid sending invalid Supabase values

## Testing
- node -e "import('./assets/data-proxy.js').then(() => console.log('data-proxy ok')).catch(err => { console.error(err); process.exit(1); });"

------
https://chatgpt.com/codex/tasks/task_e_68d37d43303c8321bdc26a286e18dc0d