### PR TITLE
Style communauté aligné sur commentaires timeline

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1700,45 +1700,6 @@ section[data-route="/community"] .topic-body > *{
   position:relative;
   z-index:1;
 }
-section[data-route="/community"] .topic-content{font-size:15px; line-height:1.7; color:#f6f7ff; word-break:break-word}
-section[data-route="/community"] .topic-empty{
-  margin:0;
-  padding:14px 16px;
-  border-radius:18px;
-  text-align:center;
-  font-size:14px;
-  color:rgba(226,233,255,.78);
-  background:rgba(255,255,255,.06);
-  border:1px dashed rgba(255,255,255,.2);
-}
-section[data-route="/community"] .topic-replies{display:grid; gap:14px}
-section[data-route="/community"] .reply{
-  display:grid;
-  gap:10px;
-  padding:16px 18px;
-  border-radius:20px;
-  background:rgba(0,0,0,.55);
-  border:1px solid rgba(255,255,255,.12);
-  box-shadow:0 18px 36px rgba(0,0,0,.45);
-}
-section[data-route="/community"] .reply-head{display:flex; align-items:center; gap:12px; justify-content:flex-start; flex-wrap:wrap}
-section[data-route="/community"] .reply-head .btn-message{margin-left:auto}
-section[data-route="/community"] .reply-avatar{
-  flex:0 0 auto;
-  width:42px;
-  height:42px;
-  border-radius:14px;
-  display:grid;
-  place-items:center;
-  font-weight:700;
-  font-size:16px;
-  color:#131924;
-  background:linear-gradient(135deg, rgba(255,225,200,.7), rgba(183,211,255,.6));
-  box-shadow:0 10px 20px rgba(0,0,0,.38);
-}
-section[data-route="/community"] .reply-meta{display:grid; gap:4px; min-width:0}
-section[data-route="/community"] .reply-meta time{font-size:12px; color:rgba(226,233,255,.7)}
-section[data-route="/community"] .reply-body{font-size:14px; line-height:1.6; color:#f0f3ff; word-break:break-word}
 section[data-route="/community"] .btn-message{background:rgba(255,255,255,.1); border:1px solid rgba(255,255,255,.2); color:#ffffff; box-shadow:none}
 section[data-route="/community"] .btn-message:hover{background:rgba(255,255,255,.18)}
 section[data-route="/community"] .btn-message--small{padding:6px 10px; font-size:13px; border-radius:12px}
@@ -3247,4 +3208,82 @@ section[data-route="/community"] .btn-danger:hover{
 .ai-tools-showcase{
   text-align:center;
   padding-top:0;
+}
+section[data-route="/community"] .topic-thread{
+  display:grid;
+  gap:18px;
+}
+section[data-route="/community"] .topic-entry{
+  display:grid;
+  gap:12px;
+}
+section[data-route="/community"] .topic-entry__head{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  flex-wrap:wrap;
+}
+section[data-route="/community"] .topic-entry__avatar{
+  flex:0 0 auto;
+  width:44px;
+  height:44px;
+  border-radius:14px;
+  display:grid;
+  place-items:center;
+  font-weight:700;
+  font-size:16px;
+  color:#131924;
+  background:linear-gradient(135deg, rgba(255,225,200,.7), rgba(183,211,255,.6));
+  box-shadow:0 10px 20px rgba(0,0,0,.38);
+}
+section[data-route="/community"] .topic-entry__meta{
+  display:grid;
+  gap:4px;
+  min-width:0;
+  flex:1 1 auto;
+}
+section[data-route="/community"] .topic-entry__author{
+  display:flex;
+  align-items:center;
+  flex-wrap:wrap;
+  gap:8px;
+}
+section[data-route="/community"] .topic-entry__author-name{
+  font-size:15px;
+  font-weight:700;
+  color:#ffffff;
+}
+section[data-route="/community"] .topic-entry__meta time{
+  font-size:12px;
+  letter-spacing:.02em;
+  color:rgba(226,233,255,.72);
+}
+section[data-route="/community"] .topic-entry__actions{
+  margin-left:auto;
+  display:flex;
+  align-items:center;
+  gap:8px;
+  flex:0 0 auto;
+}
+section[data-route="/community"] .topic-entry .timeline-parent-note,
+section[data-route="/community"] .topic-entry .timeline-ai-note{
+  margin:0;
+}
+section[data-route="/community"] .topic-entry .timeline-parent-note__text,
+section[data-route="/community"] .topic-entry .timeline-ai-note__text{
+  word-break:break-word;
+}
+section[data-route="/community"] .topic-empty{
+  margin:0;
+  padding:14px 16px;
+  border-radius:18px;
+  text-align:center;
+  font-size:14px;
+  color:rgba(226,233,255,.78);
+  background:rgba(255,255,255,.06);
+  border:1px dashed rgba(255,255,255,.2);
+}
+section[data-route="/community"] .topic-empty--thread{
+  justify-self:center;
+  max-width:520px;
 }


### PR DESCRIPTION
## Summary
- refactor community topic rendering to reuse the parent/IA conversation visuals from the health timeline when comments are opened
- detect Ped’IA authors to display IA-styled response cards and generate a structured thread markup
- update community styles to support the new topic thread layout while keeping the collapsed card appearance intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3a7ba38948321a7a5530761e55196