### PR TITLE
Remove refresh button from settings header

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,9 +794,6 @@
         <div class="page-header">
           <h2>Paramètres</h2>
           <p class="page-subtitle">Profil, confidentialité et gestion multi‑enfants.</p>
-          <div class="page-actions">
-            <button id="btn-refresh-settings" class="btn btn-secondary">Rafraîchir</button>
-          </div>
         </div>
         <div class="grid-2">
           <form id="form-settings" class="card form-grid">


### PR DESCRIPTION
## Summary
- remove the redundant refresh action from the settings page header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3ab2fb7088321af045d756522ef23