### PR TITLE
Fix growth metrics injection in AI prompts

### DIFF
--- a/lib/anon-children.js
+++ b/lib/anon-children.js
@@ -25,8 +25,13 @@ class HttpError extends Error {
 function getServiceConfig() {
   const supaUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || '';
-  if (!supaUrl || !serviceKey) {
-    throw new HttpError(500, 'Server misconfigured');
+  if (!supaUrl) {
+    console.error('[service-config] Missing Supabase URL (NEXT_PUBLIC_SUPABASE_URL/SUPABASE_URL)');
+    throw new HttpError(500, 'Missing SUPABASE_URL');
+  }
+  if (!serviceKey) {
+    console.error('[service-config] Missing Supabase service role key (SUPABASE_SERVICE_ROLE_KEY)');
+    throw new HttpError(500, 'Missing SUPABASE_SERVICE_ROLE_KEY');
   }
   return { supaUrl, serviceKey };
 }


### PR DESCRIPTION
## Summary
- emit explicit SUPABASE configuration errors when the service key or URL is missing
- pull recent growth measurements and teeth counts for each child when building AI prompts, including family bilan payloads
- reuse the shared service configuration in growth fetches and query enriched measurement fields so the AI receives concrete data

## Testing
- `node -e "import('./api/ai.js').then(()=>console.log('ai loaded')).catch((err)=>{console.error(err); process.exit(1);})"`


------
https://chatgpt.com/codex/tasks/task_e_68d4286a8c8c8321a0c19faba0006ccb