### PR TITLE
Add guest login flow backed by Supabase admin API

### DIFF
--- a/api/guest-create.js
+++ b/api/guest-create.js
@@ -1,0 +1,147 @@
+import { randomBytes, randomUUID } from 'crypto';
+
+function generateGuestEmail() {
+  return `anon_${randomUUID()}@guest.local`;
+}
+
+function generateGuestPassword(length = 16) {
+  let output = '';
+  while (output.length < length) {
+    output += randomBytes(length).toString('base64url');
+  }
+  return output.slice(0, Math.max(length, 12));
+}
+
+async function readBody(req) {
+  let body = '';
+  for await (const chunk of req) body += chunk;
+  return body;
+}
+
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
+}
+
+async function deleteUserIfPossible(supaUrl, serviceKey, userId) {
+  if (!userId) return;
+  try {
+    await fetch(`${supaUrl}/auth/v1/admin/users/${encodeURIComponent(userId)}`, {
+      method: 'DELETE',
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+      },
+    });
+  } catch (err) {
+    console.warn('[api/guest-create] cleanup delete failed', err);
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    setCors(res);
+    return res.status(204).end();
+  }
+
+  if (req.method !== 'POST') {
+    setCors(res);
+    res.setHeader('Allow', 'POST,OPTIONS');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const supaUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || '';
+    if (!supaUrl || !serviceKey) {
+      setCors(res);
+      return res.status(500).json({ error: 'Server misconfigured' });
+    }
+
+    const rawBody = await readBody(req).catch(() => '');
+    if (rawBody) {
+      try {
+        JSON.parse(rawBody);
+      } catch (err) {
+        setCors(res);
+        return res.status(400).json({ error: 'Invalid JSON body' });
+      }
+    }
+
+    const email = generateGuestEmail();
+    const password = generateGuestPassword(16);
+
+    const createResponse = await fetch(`${supaUrl}/auth/v1/admin/users`, {
+      method: 'POST',
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email,
+        password,
+        email_confirm: true,
+        user_metadata: { is_guest: true },
+        app_metadata: { role: 'guest' },
+      }),
+    });
+
+    const createText = await createResponse.text().catch(() => '');
+    let createJson = null;
+    if (createText) {
+      try { createJson = JSON.parse(createText); } catch (err) {
+        console.warn('[api/guest-create] unable to parse create user response', err);
+      }
+    }
+
+    if (!createResponse.ok) {
+      console.error('[api/guest-create] user create failed', createText);
+      setCors(res);
+      const message = createJson?.message || createJson?.error || 'Unable to create guest user';
+      return res.status(500).json({ error: message || 'Unable to create guest user' });
+    }
+
+    const user = createJson?.user || createJson;
+    const userId = user?.id || user?.user?.id;
+    if (!userId) {
+      console.error('[api/guest-create] missing user id in response');
+      setCors(res);
+      return res.status(500).json({ error: 'Invalid Supabase response' });
+    }
+
+    const profilePayload = {
+      user_id: userId,
+      is_guest: true,
+      created_at: new Date().toISOString(),
+    };
+
+    const profileResponse = await fetch(`${supaUrl}/rest/v1/profiles`, {
+      method: 'POST',
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(profilePayload),
+    });
+
+    if (!profileResponse.ok) {
+      const details = await profileResponse.text().catch(() => '');
+      console.error('[api/guest-create] profile insert failed', details);
+      await deleteUserIfPossible(supaUrl, serviceKey, userId);
+      setCors(res);
+      return res.status(500).json({ error: 'Unable to create guest profile' });
+    }
+
+    setCors(res);
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    return res.status(200).json({ email, password });
+  } catch (err) {
+    console.error('[api/guest-create] handler error', err);
+    setCors(res);
+    return res.status(500).json({ error: 'Server error', details: err?.message || String(err) });
+  }
+}

--- a/assets/messages.js
+++ b/assets/messages.js
@@ -169,6 +169,59 @@ async function createAnonymousProfile(){
   }
 }
 
+async function loginAsGuest() {
+  const btn = $('#guest-login-btn');
+  const status = $('#guest-login-status');
+  if (btn?.dataset.busy === '1') return;
+  status?.classList.remove('error');
+  if (status) status.textContent = '';
+  const ok = await ensureSupabase();
+  if (!ok || !supabase) {
+    if (status) {
+      status.classList.add('error');
+      status.textContent = 'Service indisponible pour le moment.';
+    } else {
+      alert('Impossible de créer un invité pour le moment.');
+    }
+    return;
+  }
+  try {
+    if (btn) { btn.dataset.busy = '1'; btn.disabled = true; }
+    if (status) status.textContent = 'Création du compte invité…';
+    const response = await fetch('/api/guest-create', { method: 'POST' });
+    const text = await response.text().catch(() => '');
+    let payload = null;
+    if (text) {
+      try { payload = JSON.parse(text); } catch { payload = null; }
+    }
+    if (!response.ok || !payload?.email || !payload?.password) {
+      const message = payload?.error || 'Impossible de créer un invité pour le moment.';
+      throw new Error(message);
+    }
+    if (status) status.textContent = 'Connexion invitée…';
+    const { data, error } = await supabase.auth.signInWithPassword({ email: payload.email, password: payload.password });
+    if (error || !data?.session) {
+      throw new Error(error?.message || 'Connexion invitée impossible.');
+    }
+    if (status) {
+      status.classList.remove('error');
+      status.textContent = 'Connexion invitée réussie, redirection…';
+    }
+    location.href = '/#/settings';
+  } catch (e) {
+    console.error('loginAsGuest failed', e);
+    const message = e instanceof Error && e.message ? e.message : 'Impossible de créer un invité pour le moment.';
+    if (status) {
+      status.classList.add('error');
+      status.textContent = message;
+    } else {
+      alert('Impossible de créer un invité pour le moment.');
+    }
+  } finally {
+    if (btn) { btn.dataset.busy = '0'; btn.disabled = false; }
+  }
+}
+
 async function loginWithCode(){
   const input = $('#anon-code-input');
   const status = $('#anon-login-status');
@@ -254,6 +307,10 @@ function setupLoginUI(){
   $('#btn-create-anon')?.addEventListener('click', (e) => {
     e.preventDefault();
     createAnonymousProfile();
+  });
+  $('#guest-login-btn')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    loginAsGuest();
   });
   $('#btn-login-code')?.addEventListener('click', (e) => {
     e.preventDefault();

--- a/index.html
+++ b/index.html
@@ -401,6 +401,8 @@
               <p class="login-panel__text">Générez un code confidentiel pour profiter de l’application sans partager d’informations personnelles.</p>
             </div>
             <button class="btn btn-secondary login-panel__action" type="button" id="btn-create-anon">Créer un code anonyme</button>
+            <button class="btn btn-secondary login-panel__action" type="button" id="guest-login-btn">Continuer en invité</button>
+            <div id="guest-login-status" class="form-status" aria-live="polite"></div>
             <div id="anon-create-status" class="form-status" aria-live="polite"></div>
             <div class="login-panel__divider" role="separator"><span>Déjà un code&nbsp;?</span></div>
             <label class="login-code-label" for="anon-code-input">Entrez votre code unique</label>

--- a/messages.html
+++ b/messages.html
@@ -119,6 +119,8 @@
             <p class="login-panel__text">Générez un code confidentiel pour accéder à vos messages en toute discrétion.</p>
           </div>
           <button class="btn btn-secondary login-panel__action" type="button" id="btn-create-anon">Créer un code anonyme</button>
+          <button class="btn btn-secondary login-panel__action" type="button" id="guest-login-btn">Continuer en invité</button>
+          <div id="guest-login-status" class="form-status" aria-live="polite"></div>
           <div id="anon-create-status" class="form-status" aria-live="polite"></div>
           <div class="login-panel__divider" role="separator"><span>Déjà un code&nbsp;?</span></div>
           <label class="login-code-label" for="anon-code-input">Entrez votre code unique</label>


### PR DESCRIPTION
## Summary
- add a serverless route that creates guest Supabase users with the service role and persists a guest profile
- surface a "Continuer en invité" CTA on the login views with status messaging
- wire the SPA and messages login flows to call the guest route and sign the visitor in before redirecting

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d47a98d2fc8321b96bbb41a9465e5a