### PR TITLE
Améliore la gestion IA de la croissance et l'accueil enfant

### DIFF
--- a/assets/ia.js
+++ b/assets/ia.js
@@ -1,19 +1,34 @@
 export function summarizeGrowthStatus(growth) {
   if (!growth || typeof growth !== 'object') return null;
   const statusGlobal = normalizeText(growth.status_global ?? growth.statusGlobal);
-  if (!statusGlobal || statusGlobal.toLowerCase() === 'normal') return null;
-  let summary = `⚠️ Croissance: ${statusGlobal}.`;
-
   const weightStatus = normalizeText(growth.status_weight ?? growth.statusWeight);
   const weightValueRaw = growth.weight_kg ?? growth.weightKg ?? null;
   const weightValue = Number.isFinite(Number(weightValueRaw)) ? Number(weightValueRaw) : null;
+  const heightStatus = normalizeText(growth.status_height ?? growth.statusHeight);
+  const heightValueRaw = growth.height_cm ?? growth.heightCm ?? null;
+  const heightValue = Number.isFinite(Number(heightValueRaw)) ? Number(heightValueRaw) : null;
+  const statuses = [statusGlobal, weightStatus, heightStatus].filter(Boolean);
+  if (!statuses.length) return null;
+  const isNormal = (value) => {
+    if (!value) return false;
+    const normalized = value
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z]/g, '');
+    return normalized === 'normal' || normalized === 'normale';
+  };
+  const hasAlert = statuses.some((status) => status && !isNormal(status));
+  if (!hasAlert) return null;
+
+  let summary = statusGlobal && !isNormal(statusGlobal)
+    ? `⚠️ Croissance: ${statusGlobal}.`
+    : '⚠️ Croissance: anomalie OMS détectée.';
+
   if (weightValue != null && weightStatus) {
     summary += ` Poids: ${Number(weightValue.toFixed(2))}kg (${weightStatus}).`;
   }
 
-  const heightStatus = normalizeText(growth.status_height ?? growth.statusHeight);
-  const heightValueRaw = growth.height_cm ?? growth.heightCm ?? null;
-  const heightValue = Number.isFinite(Number(heightValueRaw)) ? Number(heightValueRaw) : null;
   if (heightValue != null && heightStatus) {
     summary += ` Taille: ${Number(heightValue.toFixed(1))}cm (${heightStatus}).`;
   }

--- a/lib/anon-children.js
+++ b/lib/anon-children.js
@@ -137,7 +137,7 @@ async function fetchGrowthDataForAnonPrompt(supaUrl, headers, childId, { measure
   }
   const limitedMeasurements = Math.max(1, Math.min(6, Number.isFinite(Number(measurementLimit)) ? Number(measurementLimit) : 3));
   const limitedTeeth = Math.max(1, Math.min(6, Number.isFinite(Number(teethLimit)) ? Number(teethLimit) : 3));
-  const measurementUrl = `${supaUrl}/rest/v1/growth_measurements?select=month,height_cm,weight_kg,recorded_at,created_at&child_id=eq.${encodeURIComponent(childId)}&order=month.desc&order=created_at.desc&limit=${limitedMeasurements}`;
+  const measurementUrl = `${supaUrl}/rest/v1/child_growth_with_statut?select=agemos,month,height_cm,weight_kg,status_weight,status_height,status_global,recorded_at,created_at&child_id=eq.${encodeURIComponent(childId)}&order=agemos.desc.nullslast&limit=${limitedMeasurements}`;
   const teethUrl = `${supaUrl}/rest/v1/growth_teeth?select=month,count,recorded_at,created_at&child_id=eq.${encodeURIComponent(childId)}&order=month.desc&order=created_at.desc&limit=${limitedTeeth}`;
   const [measurementRows, teethRows] = await Promise.all([
     supabaseRequest(measurementUrl, { headers }).catch((err) => {
@@ -149,7 +149,21 @@ async function fetchGrowthDataForAnonPrompt(supaUrl, headers, childId, { measure
       return [];
     }),
   ]);
-  const measurements = Array.isArray(measurementRows) ? measurementRows.filter(Boolean) : [];
+  const measurements = Array.isArray(measurementRows)
+    ? measurementRows
+        .filter(Boolean)
+        .map((row) => ({
+          agemos: row?.agemos ?? null,
+          month: row?.month ?? null,
+          height_cm: row?.height_cm ?? null,
+          weight_kg: row?.weight_kg ?? null,
+          status_weight: row?.status_weight ?? null,
+          status_height: row?.status_height ?? null,
+          status_global: row?.status_global ?? null,
+          recorded_at: row?.recorded_at ?? null,
+          created_at: row?.created_at ?? null,
+        }))
+    : [];
   const teeth = Array.isArray(teethRows) ? teethRows.filter(Boolean) : [];
   return { measurements, teeth };
 }
@@ -165,8 +179,47 @@ function formatGrowthSectionForAnonPrompt(growthData) {
   if (teethLine) {
     lines.push(`Dents: ${teethLine}`);
   }
+  const alertLine = buildGrowthAlertSummary(growthData?.measurements);
+  if (alertLine) {
+    lines.push(`Analyse OMS: ${alertLine}`);
+  }
   if (!lines.length) return '';
   return lines.join('\n').slice(0, 600);
+}
+
+function buildGrowthAlertSummary(measurements = []) {
+  if (!Array.isArray(measurements)) return '';
+  const normalized = measurements.filter(Boolean);
+  for (const entry of normalized) {
+    const statusGlobal = sanitizeGrowthSummary(entry?.status_global);
+    const statusHeight = sanitizeGrowthSummary(entry?.status_height);
+    const statusWeight = sanitizeGrowthSummary(entry?.status_weight);
+    const statuses = [statusGlobal, statusHeight, statusWeight].filter(Boolean);
+    if (!statuses.length) continue;
+    const hasAlert = statuses.some((status) => status && !isStatusLabelNormal(status));
+    if (!hasAlert) continue;
+    let summary = statusGlobal ? `⚠️ Croissance: ${statusGlobal}.` : '⚠️ Croissance: anomalie OMS détectée.';
+    if (statusWeight) {
+      const weightText = formatGrowthNumber(entry?.weight_kg, { unit: 'kg', decimals: 2 });
+      if (weightText) summary += ` Poids: ${weightText} (${statusWeight}).`;
+    }
+    if (statusHeight) {
+      const heightText = formatGrowthNumber(entry?.height_cm, { unit: 'cm', decimals: 1 });
+      if (heightText) summary += ` Taille: ${heightText} (${statusHeight}).`;
+    }
+    return summary.trim();
+  }
+  return '';
+}
+
+function isStatusLabelNormal(status) {
+  if (!status) return true;
+  const normalized = status
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z]/g, '');
+  return normalized === 'normal' || normalized === 'normale';
 }
 
 function formatGrowthMeasurementsForPrompt(measurements = []) {
@@ -180,12 +233,31 @@ function formatGrowthMeasurementEntry(entry) {
   if (!entry || typeof entry !== 'object') return '';
   const parts = [];
   const heightText = formatGrowthNumber(entry.height_cm, { unit: 'cm', decimals: 1 });
-  if (heightText) parts.push(`taille ${heightText}`);
+  if (heightText) {
+    let label = `taille ${heightText}`;
+    const status = sanitizeGrowthSummary(entry.status_height);
+    if (status) label += ` (statut: ${status})`;
+    parts.push(label);
+  }
   const weightText = formatGrowthNumber(entry.weight_kg, { unit: 'kg', decimals: 2 });
-  if (weightText) parts.push(`poids ${weightText}`);
+  if (weightText) {
+    let label = `poids ${weightText}`;
+    const status = sanitizeGrowthSummary(entry.status_weight);
+    if (status) label += ` (statut: ${status})`;
+    parts.push(label);
+  }
   if (!parts.length) return '';
+  const globalStatus = sanitizeGrowthSummary(entry.status_global);
+  if (globalStatus) {
+    const label = `statut global: ${globalStatus}`;
+    if (!parts.includes(label)) parts.push(label);
+  }
+  const uniqueParts = [];
+  parts.forEach((part) => {
+    if (!uniqueParts.includes(part)) uniqueParts.push(part);
+  });
   const period = formatGrowthPeriod(entry);
-  return period ? `${period}: ${parts.join(' ; ')}` : parts.join(' ; ');
+  return period ? `${period}: ${uniqueParts.join(' ; ')}` : uniqueParts.join(' ; ');
 }
 
 function formatGrowthTeethForPrompt(teethEntries = []) {
@@ -203,13 +275,35 @@ function formatGrowthTeethForPrompt(teethEntries = []) {
 
 function formatGrowthPeriod(entry) {
   if (!entry || typeof entry !== 'object') return '';
-  const month = Number(entry.month);
-  if (Number.isFinite(month) && month >= 0) {
-    return `mois ${month}`;
-  }
+  const ageText = formatGrowthAge(entry);
+  if (ageText) return ageText;
   const recorded = typeof entry.recorded_at === 'string' ? entry.recorded_at : '';
   const created = typeof entry.created_at === 'string' ? entry.created_at : '';
   return formatDateForPrompt(recorded) || formatDateForPrompt(created) || '';
+}
+
+function formatGrowthAge(entry) {
+  if (!entry || typeof entry !== 'object') return '';
+  const keys = ['agemos', 'age_month', 'ageMonth', 'month', 'months', 'age_in_months'];
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(entry, key)) continue;
+    const raw = entry[key];
+    if (raw === undefined || raw === null || raw === '') continue;
+    const numeric = Number(raw);
+    if (Number.isFinite(numeric)) {
+      const rounded = numeric % 1 === 0 ? numeric : Number(numeric.toFixed(1));
+      return `mois ${String(rounded).replace(/\.0+$/, '')}`;
+    }
+    const text = sanitizeGrowthSummary(raw);
+    if (text) return `mois ${text}`;
+  }
+  return '';
+}
+
+function sanitizeGrowthSummary(value) {
+  if (value === undefined || value === null) return '';
+  const text = typeof value === 'string' ? value : String(value);
+  return text.trim().slice(0, 200);
 }
 
 function formatGrowthNumber(value, { unit = '', decimals = 1 } = {}) {
@@ -247,15 +341,18 @@ async function callOpenAi(messages, { temperature = 0.4 } = {}) {
   return json?.choices?.[0]?.message?.content?.trim() || '';
 }
 
-async function generateAiSummary(updateType, updateText, parentComment, growthSection) {
+async function generateAiSummary(updateType, updateText, parentComment, growthSection, growthAlert) {
   if (!OPENAI_API_KEY || !updateText) return '';
-  const system = "Tu es Ped’IA. Résume factuellement la mise à jour fournie en français, en 50 mots maximum. Bannis toute donnée extérieure et concentre-toi uniquement sur la mise à jour, le commentaire parent et les données de croissance transmises.";
+  const system = "Tu es Ped’IA. Résume factuellement la mise à jour fournie en français, en 50 mots maximum. Bannis toute donnée extérieure et concentre-toi uniquement sur la mise à jour, le commentaire parent et les données de croissance transmises. Si les statuts OMS indiquent une anomalie (statut global, taille ou poids différent de 'normal'), ajoute une phrase d'alerte explicite.";
   const userParts = [];
   if (updateType) userParts.push(`Type de mise à jour: ${updateType}`);
   userParts.push(`Mise à jour (JSON): ${updateText}`);
   userParts.push(`Commentaire du parent: ${parentComment || 'Aucun'}`);
   if (growthSection) {
     userParts.push(`Section Croissance:\n${growthSection}`);
+  }
+  if (growthAlert) {
+    userParts.push(`Alerte OMS prioritaire: ${growthAlert}`);
   }
   const user = userParts.join('\n\n');
   return callOpenAi([
@@ -264,12 +361,12 @@ async function generateAiSummary(updateType, updateText, parentComment, growthSe
   ], { temperature: 0.2 });
 }
 
-async function generateAiCommentaire(updateType, updateText, parentComment, previousSummaries, latestSummary, growthSection) {
+async function generateAiCommentaire(updateType, updateText, parentComment, previousSummaries, latestSummary, growthSection, growthAlert) {
   if (!OPENAI_API_KEY) return '';
   const history = Array.isArray(previousSummaries) && previousSummaries.length
     ? previousSummaries.map((s, idx) => `${idx + 1}. ${s}`).join('\n')
     : 'Aucun historique disponible';
-  const system = "Tu es Ped’IA, assistant parental bienveillant. Rédige un commentaire personnalisé (80 mots max) basé uniquement sur la nouvelle mise à jour, le commentaire parent, les données de croissance fournies et les résumés factuels. Ne réutilise jamais d’anciens commentaires IA. Sois chaleureux, concret et rassurant.";
+  const system = "Tu es Ped’IA, assistant parental bienveillant. Rédige un commentaire personnalisé (80 mots max) basé uniquement sur la nouvelle mise à jour, le commentaire parent, les données de croissance fournies et les résumés factuels. Ne réutilise jamais d’anciens commentaires IA. Sois chaleureux, concret et rassurant. Si une anomalie OMS apparaît dans les données, mentionne-la clairement dans ton commentaire.";
   const parts = [];
   if (updateType) parts.push(`Type de mise à jour: ${updateType}`);
   parts.push(`Historique des résumés (du plus récent au plus ancien):\n${history}`);
@@ -278,6 +375,9 @@ async function generateAiCommentaire(updateType, updateText, parentComment, prev
   parts.push(`Commentaire du parent: ${parentComment || 'Aucun'}`);
   if (growthSection) {
     parts.push(`Croissance récente:\n${growthSection}`);
+  }
+  if (growthAlert) {
+    parts.push(`Alerte OMS à intégrer absolument: ${growthAlert}`);
   }
   const user = parts.join('\n\n');
   return callOpenAi([
@@ -524,6 +624,36 @@ function buildSleepRecords(input) {
   return out;
 }
 
+function buildChildWelcomeComment(firstName) {
+  const safeName = typeof firstName === 'string' ? firstName.trim().slice(0, 120) : '';
+  if (safeName) {
+    return `Bienvenue ${safeName} dans Synap’Kids ! Ton profil vient d’être créé. Chaque mise à jour aidera tes parents à suivre ta croissance et ton développement.`;
+  }
+  return "Bienvenue dans Synap’Kids ! Ton profil vient d’être créé. Chaque mise à jour aidera tes parents à suivre ta croissance et ton développement.";
+}
+
+async function insertChildWelcomeUpdate({ supaUrl, headers, childId, firstName }) {
+  if (!supaUrl || !headers || !childId) return;
+  const comment = buildChildWelcomeComment(firstName);
+  if (!comment) return;
+  const payload = [{
+    child_id: childId,
+    update_type: 'ai_welcome',
+    update_content: JSON.stringify({ summary: 'Création du profil enfant' }),
+    ai_summary: 'Profil enfant créé.',
+    ai_commentaire: comment,
+  }];
+  try {
+    await supabaseRequest(`${supaUrl}/rest/v1/child_updates`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json', Prefer: 'return=representation' },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    console.warn('[anon-children] unable to insert welcome comment', { childId, err });
+  }
+}
+
 // Charge un profil anonyme à partir de son code unique et refuse les comptes déjà liés à un utilisateur
 async function fetchAnonProfile(supaUrl, serviceKey, code) {
   const headers = { 'apikey': serviceKey, 'Authorization': `Bearer ${serviceKey}` };
@@ -708,6 +838,12 @@ export async function processAnonChildrenRequest(body) {
           }
         );
       }
+      await insertChildWelcomeUpdate({
+        supaUrl,
+        headers,
+        childId,
+        firstName: childPayload.first_name,
+      });
       return { status: 200, body: { child: row } };
     }
 
@@ -834,9 +970,10 @@ export async function processAnonChildrenRequest(body) {
       if (OPENAI_API_KEY) {
         const growthData = await fetchGrowthDataForAnonPrompt(supaUrl, headers, childId, { measurementLimit: 3, teethLimit: 3 });
         const growthSection = formatGrowthSectionForAnonPrompt(growthData);
-        aiSummary = await generateAiSummary(updateType, updateText, parentComment, growthSection);
+        const growthAlert = buildGrowthAlertSummary(growthData?.measurements);
+        aiSummary = await generateAiSummary(updateType, updateText, parentComment, growthSection, growthAlert);
         const previousSummaries = await fetchRecentSummaries(supaUrl, headers, childId, 10);
-        aiCommentaire = await generateAiCommentaire(updateType, updateText, parentComment, previousSummaries, aiSummary, growthSection);
+        aiCommentaire = await generateAiCommentaire(updateType, updateText, parentComment, previousSummaries, aiSummary, growthSection, growthAlert);
       }
       const payload = {
         child_id: childId,


### PR DESCRIPTION
## Summary
- utilise la vue `child_growth_with_statut` côté IA et propage un résumé OMS même sans mise à jour liée à la croissance
- renforce les prompts IA pour imposer une alerte explicite lorsqu’un statut OMS est anormal
- ajoute le commentaire de bienvenue automatique lors de la création d’un profil enfant anonyme

## Testing
- node --check api/ai.js
- node --check lib/anon-children.js
- node --check assets/ia.js

------
https://chatgpt.com/codex/tasks/task_e_68d5a7e549fc8321a8238339646ae2d4