### PR TITLE
Fix AI growth view usage and enforce OMS growth integration

### DIFF
--- a/api/ai.js
+++ b/api/ai.js
@@ -393,7 +393,7 @@ Ne copie pas mot pour mot le commentaire du parent : reformule et apporte un éc
           containsGrowthTerm(parentComment) ||
           containsGrowthTerm(updateText) ||
           hasGrowthTermInData(updateForPrompt);
-        const includeGrowth = hasGrowthAnomaly || isGrowthRelatedUpdate;
+        const includeGrowth = (growthData?.measurements?.length > 0) || hasGrowthAnomaly || isGrowthRelatedUpdate;
         const filteredContextParts = hasGrowthAnomaly && growthSummary
           ? contextParts.filter((entry) => !isSameGrowthSummary(entry, growthSummary))
           : contextParts;
@@ -1459,7 +1459,7 @@ async function fetchGrowthDataForPrompt({
   const limitedMeasurements = Math.max(1, Math.min(3, Number(measurementLimit) || 3));
   const limitedTeeth = Math.max(1, Math.min(3, Number(teethLimit) || 3));
   try {
-    const measurementUrl = `${effectiveUrl}/rest/v1/child_growth_with_statut?select=agemos,height_cm,weight_kg,status_weight,status_height,status_global&child_id=eq.${encodeURIComponent(childId)}&order=agemos.desc.nullslast&limit=${limitedMeasurements}`;
+    const measurementUrl = `${effectiveUrl}/rest/v1/child_growth_with_status?select=agemos,height_cm,weight_kg,status_weight,status_height,status_global&child_id=eq.${encodeURIComponent(childId)}&order=agemos.desc.nullslast&limit=${limitedMeasurements}`;
     const measurementRows = await supabaseRequest(measurementUrl, { headers: effectiveHeaders });
     const measurements = (Array.isArray(measurementRows) ? measurementRows : [])
       .filter(Boolean)

--- a/lib/anon-children.js
+++ b/lib/anon-children.js
@@ -137,7 +137,7 @@ async function fetchGrowthDataForAnonPrompt(supaUrl, headers, childId, { measure
   }
   const limitedMeasurements = Math.max(1, Math.min(6, Number.isFinite(Number(measurementLimit)) ? Number(measurementLimit) : 3));
   const limitedTeeth = Math.max(1, Math.min(6, Number.isFinite(Number(teethLimit)) ? Number(teethLimit) : 3));
-  const measurementUrl = `${supaUrl}/rest/v1/child_growth_with_statut?select=agemos,month,height_cm,weight_kg,status_weight,status_height,status_global,recorded_at,created_at&child_id=eq.${encodeURIComponent(childId)}&order=agemos.desc.nullslast&limit=${limitedMeasurements}`;
+  const measurementUrl = `${supaUrl}/rest/v1/child_growth_with_status?select=agemos,month,height_cm,weight_kg,status_weight,status_height,status_global,recorded_at,created_at&child_id=eq.${encodeURIComponent(childId)}&order=agemos.desc.nullslast&limit=${limitedMeasurements}`;
   const teethUrl = `${supaUrl}/rest/v1/growth_teeth?select=month,count,recorded_at,created_at&child_id=eq.${encodeURIComponent(childId)}&order=month.desc&order=created_at.desc&limit=${limitedTeeth}`;
   const [measurementRows, teethRows] = await Promise.all([
     supabaseRequest(measurementUrl, { headers }).catch((err) => {


### PR DESCRIPTION
## Summary
- update Supabase growth measurement fetches to use the unified `child_growth_with_status` view
- ensure anonymous AI workflow pulls growth measurements from the same view
- always include growth data in child AI summaries when measurements exist to force OMS anomaly detection

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5af0ed3748321a9697957321929b7