### PR TITLE
Add Supabase session keep-alive and auto-reload

### DIFF
--- a/assets/supabase-client.js
+++ b/assets/supabase-client.js
@@ -2,6 +2,120 @@ import { loadSupabaseEnv } from './supabase-env-loader.js';
 
 let cachedClient = null;
 let initPromise = null;
+let sessionManagerInitialized = false;
+let keepAliveIntervalId = null;
+let reloadScheduled = false;
+
+const KEEP_ALIVE_INTERVAL_MS = 60_000;
+
+function scheduleReload() {
+  if (reloadScheduled) return;
+  reloadScheduled = true;
+  if (typeof window !== 'undefined' && window?.location?.reload) {
+    window.location.reload();
+  }
+}
+
+function toStatusCode(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function isUnauthorizedError(error) {
+  if (!error) return false;
+  const candidates = [
+    error.status,
+    error.statusCode,
+    error.code,
+    error?.originalError?.status,
+    error?.originalError?.statusCode,
+    error?.response?.status,
+  ];
+  for (const candidate of candidates) {
+    const status = toStatusCode(candidate);
+    if (status === 401 || status === 403) {
+      return true;
+    }
+  }
+  const message = typeof error.message === 'string' ? error.message.toLowerCase() : '';
+  if (message.includes('unauthorized') || message.includes('jwt expired')) {
+    return true;
+  }
+  return false;
+}
+
+function setupKeepAlive(client) {
+  if (typeof window === 'undefined') return;
+  if (keepAliveIntervalId != null) return;
+
+  const runKeepAlive = async () => {
+    try {
+      const { error } = await client.from('profiles').select('id').limit(1);
+      if (error) {
+        if (isUnauthorizedError(error)) {
+          scheduleReload();
+          return;
+        }
+        console.error('Supabase keep-alive error', error);
+      }
+    } catch (error) {
+      if (isUnauthorizedError(error)) {
+        scheduleReload();
+        return;
+      }
+      console.error('Supabase keep-alive failed', error);
+    }
+  };
+
+  keepAliveIntervalId = window.setInterval(() => {
+    runKeepAlive();
+  }, KEEP_ALIVE_INTERVAL_MS);
+
+  runKeepAlive();
+}
+
+function setupSessionManagement(client) {
+  if (sessionManagerInitialized) return;
+  sessionManagerInitialized = true;
+
+  let hadActiveSession = false;
+
+  client.auth.getSession().then(({ data }) => {
+    if (data?.session) {
+      hadActiveSession = true;
+    }
+  }).catch((error) => {
+    if (isUnauthorizedError(error)) {
+      scheduleReload();
+    } else {
+      console.error('Supabase getSession failed', error);
+    }
+  });
+
+  client.auth.onAuthStateChange((event, session) => {
+    if (session) {
+      hadActiveSession = true;
+      return;
+    }
+    if (event === 'INITIAL_SESSION' && !hadActiveSession) {
+      return;
+    }
+    if (event === 'TOKEN_REFRESH_FAILED' || event === 'SIGNED_OUT' || hadActiveSession) {
+      scheduleReload();
+    }
+  });
+
+  setupKeepAlive(client);
+}
 
 const DEFAULT_OPTIONS = {
   auth: {
@@ -34,7 +148,10 @@ export function getSupabaseClientSync() {
 }
 
 export async function getSupabaseClient(options = {}) {
-  if (cachedClient) return cachedClient;
+  if (cachedClient) {
+    setupSessionManagement(cachedClient);
+    return cachedClient;
+  }
   if (!initPromise) {
     initPromise = (async () => {
       const env = await loadSupabaseEnv();
@@ -47,6 +164,7 @@ export async function getSupabaseClient(options = {}) {
       }
       const client = createClient(env.url, env.anonKey, buildClientOptions(options));
       cachedClient = client;
+      setupSessionManagement(client);
       return client;
     })();
   }


### PR DESCRIPTION
## Summary
- add centralized auth state listener to reload the app when the Supabase session becomes invalid
- add a keep-alive ping to maintain active sessions and trigger reloads on unauthorized responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d67bfbadd0832182d9a1aa60cc5817