### PR TITLE
Enrich parent update AI prompts with family context data

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -622,6 +622,20 @@ const TIMELINE_MILESTONES = [
         parentComment,
         parentContext: buildParentContextForPrompt(),
       };
+      const profileId = getActiveProfileId();
+      if (profileId) {
+        const normalizedProfileId = String(profileId).trim();
+        if (normalizedProfileId) {
+          payload.profileId = normalizedProfileId;
+          payload.profile_id = normalizedProfileId;
+        }
+      }
+      const codeUnique = activeProfile?.code_unique
+        ? String(activeProfile.code_unique).trim().toUpperCase()
+        : '';
+      if (codeUnique) {
+        payload.code_unique = codeUnique;
+      }
       const res = await fetch('/api/ai', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- fetch `family_context.ai_bilan` with the correct Supabase credentials depending on the parent authentication flow
- expose the AI bilan context in the parent update prompt so the AI can react to both the new update and the children’s status
- send the active profile id/code from the client when asking for an AI comment to enable the enriched context

## Testing
- node -e "import('./api/ai.js').then(()=>console.log('ai module ok')).catch((err)=>{console.error(err);process.exit(1);})"

------
https://chatgpt.com/codex/tasks/task_e_68d6fe40e0bc8321ada4cbc2e39e7301