### PR TITLE
Add fallback children from ai bilan when child context missing

### DIFF
--- a/api/ai.js
+++ b/api/ai.js
@@ -194,6 +194,96 @@ function normalizeGrowthStatus(entry) {
   return 'non renseigné';
 }
 
+const CRITICAL_GROWTH_KEYWORDS = ['trop bas', 'trop eleve', 'a surveiller', 'retard', 'hors norme'];
+
+function normalizeWithoutDiacritics(text) {
+  if (typeof text !== 'string') return '';
+  return text
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+function containsCriticalGrowthKeywords(text) {
+  if (!text) return false;
+  const normalized = normalizeWithoutDiacritics(String(text));
+  return CRITICAL_GROWTH_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+function extractChildrenFromAiBilanText(text) {
+  if (typeof text !== 'string') return [];
+  const lines = text.split(/\r?\n/);
+  const results = [];
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line.startsWith('-')) continue;
+    const match = /^-\s*\*\*(.+?)\*\*\s*[:\-–—]?\s*(.+)$/.exec(line);
+    if (!match) continue;
+    const name = match[1]?.trim().slice(0, 80) || 'Enfant';
+    const growth = match[2]?.trim();
+    if (!growth) continue;
+    if (!containsCriticalGrowthKeywords(growth)) continue;
+    results.push({ name, growth });
+  }
+  return results;
+}
+
+function buildFallbackChildrenFromAiBilan(aiBilan) {
+  if (!aiBilan) return [];
+  const children = [];
+
+  const tryPushEntry = (entry) => {
+    if (!entry) return;
+    const name = typeof entry.name === 'string' ? entry.name.trim().slice(0, 80) : '';
+    let growthText = '';
+    if (typeof entry.growth === 'string') {
+      growthText = entry.growth.trim();
+    } else if (entry.growth && typeof entry.growth === 'object') {
+      const growthCandidates = [
+        entry.growth.status_global,
+        entry.growth.statusGlobal,
+        entry.growth.summary,
+        entry.growth.comment,
+      ];
+      for (const candidate of growthCandidates) {
+        if (typeof candidate === 'string' && candidate.trim()) {
+          growthText = candidate.trim();
+          break;
+        }
+      }
+    }
+    if (!growthText || !containsCriticalGrowthKeywords(growthText)) return;
+    children.push({ name: name || 'Enfant', growth: growthText });
+  };
+
+  if (Array.isArray(aiBilan)) {
+    aiBilan.forEach(tryPushEntry);
+    if (children.length) return children;
+  }
+
+  if (aiBilan && typeof aiBilan === 'object') {
+    if (Array.isArray(aiBilan.children)) {
+      aiBilan.children.forEach(tryPushEntry);
+      if (children.length) return children;
+    }
+    if (typeof aiBilan.text === 'string' && aiBilan.text.trim()) {
+      const parsed = extractChildrenFromAiBilanText(aiBilan.text);
+      if (parsed.length) return parsed;
+    }
+    if (typeof aiBilan.ai_preview === 'string' && aiBilan.ai_preview.trim()) {
+      const parsed = extractChildrenFromAiBilanText(aiBilan.ai_preview);
+      if (parsed.length) return parsed;
+    }
+  }
+
+  const textCandidate = typeof aiBilan === 'string' ? aiBilan : '';
+  if (textCandidate) {
+    return extractChildrenFromAiBilanText(textCandidate);
+  }
+
+  return children;
+}
+
 function buildDefaultParentChildContext() {
   return {
     parent: { ...DEFAULT_PARENT_CHILD_CONTEXT.parent },
@@ -238,9 +328,19 @@ async function buildContext(profileId) {
       normalized
     )}&order=dob.asc`;
 
+    let childrenRequestFailed = false;
+    const childrenPromise = supabaseRequest(childrenUrl, { headers }).catch((err) => {
+      childrenRequestFailed = true;
+      console.warn('[ai] buildContext children fallback triggered', {
+        profileId: normalized,
+        details: err?.message || err,
+      });
+      return [];
+    });
+
     const [profileRowRaw, childrenRowsRaw] = await Promise.all([
       supabaseRequest(profileUrl, { headers }).catch(() => null),
-      supabaseRequest(childrenUrl, { headers }).catch(() => []),
+      childrenPromise,
     ]);
 
     const profileRow = Array.isArray(profileRowRaw) ? profileRowRaw[0] : profileRowRaw;
@@ -256,6 +356,36 @@ async function buildContext(profileId) {
     };
 
     if (!childrenRows.length) {
+      let fallbackChildren = [];
+      try {
+        const familyContextUrl = `${supaUrl}/rest/v1/family_context?select=ai_bilan&profile_id=eq.${encodeURIComponent(
+          normalized
+        )}&order=last_generated_at.desc&limit=1`;
+        const familyContextRows = await supabaseRequest(familyContextUrl, { headers }).catch((err) => {
+          if (!childrenRequestFailed) {
+            console.warn('[ai] buildContext family_context fallback fetch failed', {
+              profileId: normalized,
+              details: err?.message || err,
+            });
+          }
+          return [];
+        });
+        const familyContextRow = Array.isArray(familyContextRows)
+          ? familyContextRows[0]
+          : familyContextRows;
+        fallbackChildren = buildFallbackChildrenFromAiBilan(familyContextRow?.ai_bilan);
+      } catch (err) {
+        console.warn('[ai] buildContext unable to build fallback children', {
+          profileId: normalized,
+          details: err?.message || err,
+        });
+      }
+
+      if (fallbackChildren.length) {
+        context.children = fallbackChildren;
+        console.log('[AI DEBUG] fallback children used:', context.children);
+      }
+
       return context;
     }
 
@@ -609,29 +739,44 @@ Prends en compte les champs du profil (allergies, type d’alimentation, style d
             : []
         );
         const summarizedContextJson = JSON.stringify(summarizedContext);
-        const growthAnomalyChildren = Array.isArray(summarizedContext?.children)
+        const contextChildren = Array.isArray(summarizedContext?.children)
           ? summarizedContext.children
-              .map((child, index) => {
-                if (!child || typeof child !== 'object') return null;
-                const rawName = typeof child.name === 'string' ? child.name.trim() : '';
-                const displayName = rawName || `Enfant #${index + 1}`;
-                const growthText = typeof child.growth === 'string' ? child.growth.trim() : '';
-                if (!growthText) return null;
-                const normalizedGrowth = growthText
-                  .toLowerCase()
-                  .normalize('NFD')
-                  .replace(/[\u0300-\u036f]/g, '');
-                const hasRetard = /\bretard\b/.test(normalizedGrowth) &&
-                  !/(pas\s+de|aucun|sans)\s+retard/.test(normalizedGrowth);
-                const hasSurveillance = /(a|à)\s*surveiller/.test(normalizedGrowth);
-                const hasHorsNorme = /hors\s*norme/.test(normalizedGrowth);
-                if (hasRetard || hasSurveillance || hasHorsNorme) {
-                  return { name: displayName, growth: growthText };
-                }
-                return null;
-              })
-              .filter(Boolean)
           : [];
+        let growthAnomalyChildren = contextChildren
+          .map((child, index) => {
+            if (!child || typeof child !== 'object') return null;
+            const rawName = typeof child.name === 'string' ? child.name.trim() : '';
+            const displayName = rawName || `Enfant #${index + 1}`;
+            const growthText = typeof child.growth === 'string' ? child.growth.trim() : '';
+            if (!growthText) return null;
+            const normalizedGrowth = normalizeWithoutDiacritics(growthText);
+            const hasRetard = /\bretard\b/.test(normalizedGrowth) &&
+              !/(pas\s+de|aucun|sans)\s+retard/.test(normalizedGrowth);
+            const hasSurveillance = /a\s*surveiller/.test(normalizedGrowth);
+            const hasHorsNorme = /hors\s*norme/.test(normalizedGrowth);
+            const hasCritical = hasRetard || hasSurveillance || hasHorsNorme || containsCriticalGrowthKeywords(growthText);
+            if (hasCritical) {
+              return { name: displayName, growth: growthText };
+            }
+            return null;
+          })
+          .filter(Boolean);
+
+        if (!growthAnomalyChildren.length && !contextChildren.length) {
+          if (containsCriticalGrowthKeywords(familyBilanText)) {
+            const parsedFromBilan = extractChildrenFromAiBilanText(familyBilanText);
+            if (parsedFromBilan.length) {
+              growthAnomalyChildren = parsedFromBilan;
+            } else {
+              const condensed = familyBilanText.split('\n').map((line) => line.trim()).filter(Boolean);
+              const criticalLine = condensed.find((line) => containsCriticalGrowthKeywords(line));
+              const growthText = (criticalLine || familyBilanText || '').trim().slice(0, 200);
+              if (growthText) {
+                growthAnomalyChildren = [{ name: 'Enfant', growth: growthText }];
+              }
+            }
+          }
+        }
 
         const rawAiPreview = (() => {
           if (!aiBilan) return '';


### PR DESCRIPTION
## Summary
- add utilities to detect critical growth anomalies and extract child data from stored ai_bilan content
- ensure buildContext populates children from ai_bilan when the /children query fails or returns nothing, with debug logging
- fall back to family bilan text to keep growth anomaly detection populated when summarized context is empty

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d86accf4f4832184d4c3cb14a8ccc2