### PR TITLE
fix: refresh AI reports after child updates using current growth data

### DIFF
--- a/lib/anon-children.js
+++ b/lib/anon-children.js
@@ -684,6 +684,34 @@ async function fetchChild(supaUrl, serviceKey, childId) {
   return row;
 }
 
+async function invalidateFamilyContext(supaUrl, serviceKey, profileId) {
+  const normalizedProfileId = profileId == null ? '' : String(profileId).trim();
+  if (!supaUrl || !serviceKey || !normalizedProfileId) {
+    return;
+  }
+  const serviceHeaders = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    'Content-Type': 'application/json',
+  };
+  try {
+    await supabaseRequest(
+      `${supaUrl}/rest/v1/family_context?profile_id=eq.${encodeURIComponent(normalizedProfileId)}`,
+      {
+        headers: serviceHeaders,
+        method: 'PATCH',
+        body: JSON.stringify({ last_generated_at: null }),
+      }
+    );
+    console.log('[AI DEBUG] family_context invalidated', { profileId: normalizedProfileId });
+  } catch (err) {
+    console.warn('[anon-children] unable to invalidate family_context', {
+      profileId: normalizedProfileId,
+      err,
+    });
+  }
+}
+
 // Ajoute l’identifiant enfant à chaque enregistrement associé (mesures, sommeil, dents)
 function withChildId(records, childId) {
   if (!Array.isArray(records) || !records.length) return [];
@@ -849,6 +877,7 @@ export async function processAnonChildrenRequest(body) {
         childId,
         firstName: childPayload.first_name,
       });
+      await invalidateFamilyContext(supaUrl, serviceKey, profileId);
       return { status: 200, body: { child: row } };
     }
 
@@ -902,6 +931,7 @@ export async function processAnonChildrenRequest(body) {
           }
         );
       }
+      await invalidateFamilyContext(supaUrl, serviceKey, profileId);
       return { status: 200, body: { child: updatedRow } };
     }
 
@@ -996,6 +1026,7 @@ export async function processAnonChildrenRequest(body) {
         }
       );
       const row = Array.isArray(inserted) ? inserted[0] : inserted;
+      await invalidateFamilyContext(supaUrl, serviceKey, profileId);
       return { status: 200, body: { update: row } };
     }
 
@@ -1046,6 +1077,9 @@ export async function processAnonChildrenRequest(body) {
             body: JSON.stringify(teeth)
           }
         );
+      }
+      if (measurements.length || sleep.length || teeth.length) {
+        await invalidateFamilyContext(supaUrl, serviceKey, profileId);
       }
       return { status: 200, body: { success: true } };
     }


### PR DESCRIPTION
## Summary
- invalidate `family_context` after child updates and growth insertions across anonymous and authenticated flows so cached reports are cleared
- gate `scheduleFamilyContextRefresh` behind an active family mode in the UI and trigger it after successful anonymous child updates
- always fetch fresh children context from Supabase before generating child and family AI reports, only falling back to `ai_bilan` when no DB data exists, and log the payloads used

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9221ca1a0832181c31e3cc6785824