### PR TITLE
fix(ai): ignore stale family_context.ai_bilan when DB data is available

### DIFF
--- a/api/ai.js
+++ b/api/ai.js
@@ -1906,9 +1906,9 @@ Propose des recommandations précises et actionnables plutôt que des générali
           console.warn('[family-bilan] children context fetch failed', { profileId, err });
         }
         const { childrenFromDb } = childrenContext;
+        const hasChildrenFromDb = Array.isArray(childrenFromDb) && childrenFromDb.length > 0;
         console.log('[AI DEBUG] family_full_report data', { children: childrenFromDb });
         let childrenFactsText = '';
-        const hasChildrenFromDb = Array.isArray(childrenFromDb) && childrenFromDb.length > 0;
         if (hasChildrenFromDb) {
           childrenFactsText = buildChildrenFacts(childrenFromDb);
         }
@@ -1925,12 +1925,17 @@ Propose des recommandations précises et actionnables plutôt que des générali
           console.warn('[family-bilan] unable to fetch ai_bilan for fallback', { profileId, err });
         }
         const aiBilanNarrative = sanitizeAiBilan(aiBilanForContext);
-        const contextText = [
+        console.log('[AI DEBUG] family-bilan source', {
+          usedChildren: hasChildrenFromDb,
+          usedAiBilan: !hasChildrenFromDb && !!aiBilanNarrative,
+        });
+        let contextText = [
           '--- CONTEXTE ENFANTS ---',
           childrenFactsText || '(aucune donnée disponible en BDD)',
-          '',
-          aiBilanNarrative ? `--- APERÇU NARRATIF (ai_bilan) ---\n${aiBilanNarrative}` : '',
         ].join('\n');
+        if (!hasChildrenFromDb && aiBilanNarrative) {
+          contextText += `\n\n--- APERÇU NARRATIF (ai_bilan) ---\n${aiBilanNarrative}`;
+        }
         const contextFromDb = hasChildrenFromDb;
         const childIds = childrenRows.map((child) => child?.id).filter(Boolean).map(String);
         if (childIds.length) {
@@ -2159,8 +2164,8 @@ Ton ton est chaleureux, réaliste et encourageant. Mets en lien les difficultés
         }
         const { childrenFromDb } = childrenContext;
         console.log('[AI DEBUG] child_full_report data', { children: childrenFromDb });
-        let childrenFactsText = '';
         const hasChildrenFromDb = Array.isArray(childrenFromDb) && childrenFromDb.length > 0;
+        let childrenFactsText = '';
         if (hasChildrenFromDb) {
           childrenFactsText = buildChildrenFacts(childrenFromDb);
         }
@@ -2182,12 +2187,17 @@ Ton ton est chaleureux, réaliste et encourageant. Mets en lien les difficultés
           }
         }
         const aiBilanNarrative = sanitizeAiBilan(aiBilanForContext);
-        const contextText = [
+        console.log('[AI DEBUG] family-bilan source', {
+          usedChildren: hasChildrenFromDb,
+          usedAiBilan: !hasChildrenFromDb && !!aiBilanNarrative,
+        });
+        let contextText = [
           '--- CONTEXTE ENFANTS ---',
           childrenFactsText || '(aucune donnée disponible en BDD)',
-          '',
-          aiBilanNarrative ? `--- APERÇU NARRATIF (ai_bilan) ---\n${aiBilanNarrative}` : '',
         ].join('\n');
+        if (!hasChildrenFromDb && aiBilanNarrative) {
+          contextText += `\n\n--- APERÇU NARRATIF (ai_bilan) ---\n${aiBilanNarrative}`;
+        }
         const contextFromDb = hasChildrenFromDb;
 
         if (!profileId && codeUnique) {

--- a/lib/anon-children.js
+++ b/lib/anon-children.js
@@ -700,10 +700,10 @@ async function invalidateFamilyContext(supaUrl, serviceKey, profileId) {
       {
         headers: serviceHeaders,
         method: 'PATCH',
-        body: JSON.stringify({ last_generated_at: null }),
+        body: JSON.stringify({ ai_bilan: null, last_generated_at: null }),
       }
     );
-    console.log('[AI DEBUG] family_context invalidated', { profileId: normalizedProfileId });
+    console.log('[AI DEBUG] family_context reset after growth update', { profileId: normalizedProfileId });
   } catch (err) {
     console.warn('[anon-children] unable to invalidate family_context', {
       profileId: normalizedProfileId,


### PR DESCRIPTION
## Summary
- guard AI prompt context so child and family reports only use cached ai_bilan when no database data is available
- add debug logging around context selection
- clear cached family_context narratives whenever child growth data is updated

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92dfd6e908321b41444963a3d73fc