### PR TITLE
Renforce la persistance du family bilan

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -6682,6 +6682,13 @@ const TIMELINE_MILESTONES = [
         let generatedAt = result?.lastGeneratedAt || new Date().toISOString();
         const refreshed = Boolean(result?.refreshed);
         if (refreshed) {
+          if (typeof localStorage !== 'undefined') {
+            try { localStorage.removeItem('family_context'); } catch {}
+          }
+          dashboardState.family.data = null;
+          if (result?.profileId) {
+            console.log('[AI DEBUG] family-bilan cache invalidated', { profileId: result.profileId });
+          }
           try {
             const cacheKeyProfileId = result?.profileId || targetProfileId || null;
             const cacheKey = cacheKeyProfileId ? `family_context_${cacheKeyProfileId}` : null;


### PR DESCRIPTION
## Summary
- applique une résolution stricte du profil pour le bilan familial et tronque le texte IA avant l’upsert
- force l’upsert explicite dans `family_context` avec journalisation détaillée et erreurs bloquantes
- invalide le cache local côté front lorsque le bilan est régénéré

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9527f082c83218e2f7399b2dcd754