### PR TITLE
Highlight initial community publication layout

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7136,14 +7136,14 @@ const TIMELINE_MILESTONES = [
         label,
         isAi,
         isSelf,
+        isInitial,
       }) => {
         const highlight = !!(isAi || isSelf);
-        const noteClass = highlight ? 'timeline-ai-note' : 'timeline-parent-note';
-        const labelClass = highlight ? 'timeline-ai-note__label' : 'timeline-parent-note__label';
-        const textClass = highlight ? 'timeline-ai-note__text' : 'timeline-parent-note__text';
         const safeInitials = escapeHtml(initials || '✦');
         const safeAuthor = escapeHtml(authorName || 'Anonyme');
-        const safeLabel = escapeHtml(label || (isAi ? `Réponse de ${authorName}` : `Commentaire de ${authorName}`));
+        const safeLabel = escapeHtml(
+          label || (isAi ? `Réponse de ${authorName}` : `Commentaire de ${authorName}`)
+        );
         const timeHtml = timeLabel
           ? `<time datetime="${escapeHtml(timeIso || '')}">${escapeHtml(timeLabel)}</time>`
           : '';
@@ -7154,6 +7154,31 @@ const TIMELINE_MILESTONES = [
         if (highlight) entryClass += ' topic-entry--highlight';
         if (isAi) entryClass += ' topic-entry--ai';
         if (isSelf) entryClass += ' topic-entry--self';
+        if (isInitial) entryClass += ' topic-entry--origin';
+        if (isInitial) {
+          return `
+            <article class="${entryClass}">
+              <div class="topic-entry__head">
+                <div class="topic-entry__avatar" aria-hidden="true">${safeInitials}</div>
+                <div class="topic-entry__meta">
+                  <div class="topic-entry__author">
+                    <span class="topic-entry__author-name">${safeAuthor}</span>
+                    ${authorMetaHtml || ''}
+                  </div>
+                  ${timeHtml}
+                </div>
+                ${actionsHtml}
+              </div>
+              <div class="topic-initial">
+                <span class="topic-initial__badge">${safeLabel}</span>
+                <div class="topic-initial__content">${contentHtml}</div>
+              </div>
+            </article>
+          `;
+        }
+        const noteClass = highlight ? 'timeline-ai-note' : 'timeline-parent-note';
+        const labelClass = highlight ? 'timeline-ai-note__label' : 'timeline-parent-note__label';
+        const textClass = highlight ? 'timeline-ai-note__text' : 'timeline-parent-note__text';
         return `
           <article class="${entryClass}">
             <div class="topic-entry__head">
@@ -7219,9 +7244,10 @@ const TIMELINE_MILESTONES = [
           timeIso: createdIso,
           contentHtml: normalizeContent(t.content),
           messageBtn: '',
-          label: topicIsAi ? 'Message de Ped’IA' : 'Publication initiale',
+          label: topicIsAi ? 'Message de Ped’IA' : 'Présentation de la publication',
           isAi: topicIsAi,
           isSelf: topicIsSelf,
+          isInitial: true,
         });
         const repliesHtml = rs.map(r=>{
           const replyMeta = authorsMap.get(String(r.user_id)) || authorsMap.get(r.user_id) || null;

--- a/assets/style.css
+++ b/assets/style.css
@@ -3403,6 +3403,52 @@ section[data-route="/community"] .topic-entry .timeline-ai-note__label{
 section[data-route="/community"] .topic-entry .timeline-ai-note__text{
   font-size:13px;
 }
+section[data-route="/community"] .topic-entry--origin{
+  background:rgba(10,17,32,.72);
+  border:1px solid rgba(110,163,255,.32);
+  border-radius:18px;
+  padding:18px 20px;
+  box-shadow:0 16px 36px rgba(5,10,24,.46);
+}
+section[data-route="/community"] .topic-entry--origin .topic-entry__head{
+  padding-bottom:4px;
+  border-bottom:1px solid rgba(255,255,255,.08);
+  margin-bottom:12px;
+}
+section[data-route="/community"] .topic-entry--origin .topic-entry__avatar{
+  box-shadow:none;
+  background:linear-gradient(135deg, rgba(120,175,255,.9), rgba(255,229,210,.8));
+}
+section[data-route="/community"] .topic-entry--origin .topic-entry__author-name{
+  font-size:16px;
+}
+section[data-route="/community"] .topic-initial{
+  display:grid;
+  gap:10px;
+  padding:6px 0 0;
+}
+section[data-route="/community"] .topic-initial__badge{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  font-size:12px;
+  font-weight:700;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  padding:6px 12px;
+  border-radius:999px;
+  background:rgba(110,163,255,.2);
+  color:rgba(216,228,255,.95);
+}
+section[data-route="/community"] .topic-initial__content{
+  font-size:15px;
+  line-height:1.65;
+  color:#f5f7ff;
+  background:rgba(255,255,255,.03);
+  border-radius:14px;
+  padding:14px 16px;
+  border:1px solid rgba(255,255,255,.1);
+}
 section[data-route="/community"] .topic-empty{
   margin:0;
   padding:14px 16px;


### PR DESCRIPTION
## Summary
- render the initial community publication with a dedicated layout so it stands apart from replies
- add styles to emphasise the publication description with a distinct badge and content container

## Testing
- Manual QA: Opened http://localhost:3000/#/community

------
https://chatgpt.com/codex/tasks/task_e_68d99d1cb6948321ad5cee17418479da