### PR TITLE
Add forum reply like support

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -3359,6 +3359,59 @@ section[data-route="/community"] .topic-entry__actions{
   gap:8px;
   flex:0 0 auto;
 }
+section[data-route="/community"] .reply-like-bar{
+  display:flex;
+  justify-content:flex-end;
+  margin-top:8px;
+}
+section[data-route="/community"] .reply-like{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:6px 12px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,.18);
+  background:rgba(255,255,255,.06);
+  color:var(--muted);
+  font-size:14px;
+  cursor:pointer;
+  transition:background .2s ease, color .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+section[data-route="/community"] .reply-like:hover{
+  background:rgba(255,255,255,.12);
+  color:#ffffff;
+}
+section[data-route="/community"] .reply-like.is-liked{
+  background:rgba(78,124,216,.2);
+  border-color:rgba(78,124,216,.5);
+  color:var(--blue-strong);
+  box-shadow:0 10px 24px rgba(78,124,216,.25);
+}
+section[data-route="/community"] .reply-like.is-liked .reply-like__icon{
+  color:var(--blue-strong);
+}
+section[data-route="/community"] .reply-like__icon{
+  font-size:16px;
+  line-height:1;
+}
+section[data-route="/community"] .reply-like__count{
+  font-weight:600;
+}
+section[data-route="/community"] .reply-like__label{
+  font-size:13px;
+}
+section[data-route="/community"] .reply-like[disabled]{
+  opacity:.6;
+  cursor:not-allowed;
+}
+@media (max-width:720px){
+  section[data-route="/community"] .reply-like{
+    padding:6px 10px;
+  }
+  section[data-route="/community"] .reply-like__label{
+    display:none;
+  }
+}
 section[data-route="/community"] .topic-entry .timeline-parent-note,
 section[data-route="/community"] .topic-entry .timeline-ai-note{
   margin:0;

--- a/node_modules/@supabase/supabase-js/index.js
+++ b/node_modules/@supabase/supabase-js/index.js
@@ -1,0 +1,197 @@
+const DEFAULT_HEADERS = Object.freeze({});
+
+function createError(response, payload) {
+  const details = payload && typeof payload === 'object' ? payload : null;
+  const message = details?.message || details?.error_description || details?.error || response.statusText || 'Supabase error';
+  return {
+    message,
+    details: details && details !== message ? details : undefined,
+    status: response.status,
+  };
+}
+
+function normalizeTable(table) {
+  if (!table || typeof table !== 'string') throw new Error('Supabase table name required');
+  return table.trim();
+}
+
+function normalizeValue(value) {
+  if (value == null) return 'null';
+  return String(value);
+}
+
+function escapeInValue(value) {
+  return normalizeValue(value).replace(/"/g, '""');
+}
+
+class SupabaseQuery {
+  constructor({ url, table, headers }) {
+    this.url = url;
+    this.table = table;
+    this.headers = headers;
+    this.filters = [];
+    this.query = new URLSearchParams();
+    this.method = 'GET';
+    this.body = null;
+    this.prefer = null;
+    this.expectSingle = false;
+    this.expectMaybeSingle = false;
+  }
+
+  clone() {
+    const next = new SupabaseQuery({ url: this.url, table: this.table, headers: this.headers });
+    next.filters = this.filters.slice();
+    next.query = new URLSearchParams(this.query.toString());
+    next.method = this.method;
+    next.body = this.body;
+    next.prefer = this.prefer;
+    next.expectSingle = this.expectSingle;
+    next.expectMaybeSingle = this.expectMaybeSingle;
+    return next;
+  }
+
+  eq(column, value) {
+    this.filters.push({ type: 'eq', column, value: normalizeValue(value) });
+    return this;
+  }
+
+  in(column, values) {
+    const arr = Array.isArray(values) ? values : [values];
+    this.filters.push({ type: 'in', column, value: arr.map((entry) => `"${escapeInValue(entry)}"`).join(',') });
+    return this;
+  }
+
+  select(columns = '*') {
+    this.method = 'GET';
+    if (columns) this.query.set('select', columns);
+    return this;
+  }
+
+  upsert(values, options = {}) {
+    const payload = Array.isArray(values) ? values : [values];
+    this.method = 'POST';
+    this.body = JSON.stringify(payload);
+    const prefer = ['return=representation'];
+    if (options.ignoreDuplicates) prefer.push('resolution=ignore-duplicates');
+    else prefer.push('resolution=merge-duplicates');
+    this.prefer = prefer.join(',');
+    if (options.onConflict) this.query.set('on_conflict', options.onConflict);
+    return this;
+  }
+
+  delete() {
+    this.method = 'DELETE';
+    this.prefer = 'return=minimal';
+    return this;
+  }
+
+  single() {
+    this.expectSingle = true;
+    return this;
+  }
+
+  maybeSingle() {
+    this.expectMaybeSingle = true;
+    return this;
+  }
+
+  async execute() {
+    const params = new URLSearchParams(this.query.toString());
+    this.filters.forEach(({ type, column, value }) => {
+      if (!column) return;
+      if (type === 'in') {
+        if (!value) return;
+        params.append(column, `in.(${value})`);
+        return;
+      }
+      params.append(column, `eq.${value}`);
+    });
+    const target = params.toString()
+      ? `${this.url}/rest/v1/${encodeURIComponent(this.table)}?${params.toString()}`
+      : `${this.url}/rest/v1/${encodeURIComponent(this.table)}`;
+    const headers = { ...DEFAULT_HEADERS, ...this.headers };
+    if (this.prefer) headers.Prefer = this.prefer;
+    if (this.method !== 'GET' && this.method !== 'HEAD') {
+      headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+    }
+    const response = await fetch(target, {
+      method: this.method,
+      headers,
+      body: this.body,
+    });
+    const text = await response.text().catch(() => '');
+    let json = null;
+    if (text) {
+      try { json = JSON.parse(text); }
+      catch { json = text; }
+    }
+    if (!response.ok) {
+      return { data: null, error: createError(response, json) };
+    }
+    let data = json;
+    if (this.expectSingle) {
+      if (Array.isArray(json)) data = json[0] ?? null;
+      else if (json && typeof json === 'object' && 'data' in json && Array.isArray(json.data)) data = json.data[0] ?? null;
+    } else if (this.expectMaybeSingle) {
+      if (Array.isArray(json)) data = json[0] ?? null;
+    }
+    return { data, error: null };
+  }
+
+  then(onFulfilled, onRejected) {
+    return this.execute().then(onFulfilled, onRejected);
+  }
+
+  catch(onRejected) {
+    return this.execute().catch(onRejected);
+  }
+
+  finally(onFinally) {
+    return this.execute().finally(onFinally);
+  }
+}
+
+export function createClient(url, key, options = {}) {
+  if (!url || !key) {
+    throw new Error('Supabase URL and key are required');
+  }
+  const headers = {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    ...(options.global?.headers || {}),
+  };
+  const baseUrl = url.replace(/\/$/, '');
+
+  return {
+    auth: {
+      async getUser(token) {
+        if (!token) {
+          return { data: null, error: { message: 'Missing token', status: 401 } };
+        }
+        const response = await fetch(`${baseUrl}/auth/v1/user`, {
+          headers: {
+            apikey: key,
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        const text = await response.text().catch(() => '');
+        let json = null;
+        if (text) {
+          try { json = JSON.parse(text); }
+          catch { json = text; }
+        }
+        if (!response.ok) {
+          return { data: null, error: createError(response, json) };
+        }
+        const user = json?.user || json || null;
+        return { data: { user }, error: null };
+      },
+    },
+    from(table) {
+      const normalized = normalizeTable(table);
+      return new SupabaseQuery({ url: baseUrl, table: normalized, headers });
+    },
+  };
+}
+
+export default { createClient };


### PR DESCRIPTION
## Summary
- extend the `/api/server` handler to manage like, unlike, and count queries for forum replies using the Supabase service key
- add client-side like state management, optimistic toggling, and integration into the forum reply renderer
- style the reply like control to match the community UI and provide a minimal Supabase client stub for the server runtime

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a95e61a8832191a026298c142047