### PR TITLE
Fix child count visibility for anonymous community users

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7169,7 +7169,12 @@ const TIMELINE_MILESTONES = [
     const normalizeAuthorMetaForId = (raw, profileId) => {
       const normalized = normalizeAuthorMeta(raw) || { name: 'Utilisateur', childCount: null, showChildCount: false };
       const activeId = getActiveProfileId();
-      if (profileId != null && activeId != null && String(profileId) === String(activeId)) {
+      const isSelf = profileId != null && activeId != null && String(profileId) === String(activeId);
+      if (!isSelf && isAnonProfile()) {
+        normalized.childCount = null;
+        normalized.showChildCount = false;
+      }
+      if (isSelf) {
         const localCount = resolveLocalChildCount();
         if (
           Number.isFinite(localCount)

--- a/lib/anon-community.js
+++ b/lib/anon-community.js
@@ -140,8 +140,12 @@ export async function processAnonCommunityRequest(body) {
       profiles.forEach((p) => {
         if (!p?.id) return;
         const key = String(p.id);
-        const childrenCount = includeChildren && Array.isArray(p.children) ? p.children.length : 0;
-        const showFlag = showColumn ? !!p.show_children_count : false;
+        const isSelf = key === profileId;
+        const childrenCount =
+          isSelf && includeChildren && Array.isArray(p.children)
+            ? p.children.length
+            : null;
+        const showFlag = showColumn && isSelf ? !!p.show_children_count : false;
         authors[key] = {
           full_name: p.full_name || '',
           children_count: childrenCount,


### PR DESCRIPTION
## Summary
- ensure anonymous community API responses only expose child counts for the requesting profile
- hide other parents' child counts in the community UI when browsing anonymously

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dafa2a9018832189f91b6fb869ed02