### PR TITLE
Fix anonymous community child count display

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7171,8 +7171,9 @@ const TIMELINE_MILESTONES = [
       const activeId = getActiveProfileId();
       const isSelf = profileId != null && activeId != null && String(profileId) === String(activeId);
       if (!isSelf && isAnonProfile()) {
-        normalized.childCount = null;
-        normalized.showChildCount = false;
+        if (!normalized.showChildCount) {
+          normalized.childCount = null;
+        }
       }
       if (isSelf) {
         const localCount = resolveLocalChildCount();


### PR DESCRIPTION
## Summary
- preserve community child count metadata for other profiles when viewed by anonymous users
- keep child counts hidden when authors opt out of sharing the information

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dafd3dfe508321899511093bc9ef07