### PR TITLE
Fix chat conversation panel height and scrolling

### DIFF
--- a/assets/messages.js
+++ b/assets/messages.js
@@ -1196,6 +1196,8 @@ function renderMessages(){
     const meInitial = (myInitial||'').toUpperCase();
     line.innerHTML = `\n      <div class="avatar">${mine? meInitial : otherInitial}</div>\n      <div class="message"><div class="bubble ${mine?'user':'assistant'}">${escapeHTML(m.content)}</div></div>`;
     wrap.appendChild(line);
+    const convo = document.getElementById("conversation");
+    if (convo) convo.scrollTop = convo.scrollHeight;
   });
   wrap.scrollTop = wrap.scrollHeight;
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -2893,8 +2893,9 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   .ai-tool-copy h3{ font-size:17px; }
   .ai-tool-copy p{ font-size:13px; }
 }
-.chat-window{display:grid; grid-template-rows:1fr auto; gap:12px; height:360px; border:1px solid rgba(255,255,255,.15); border-radius:20px; padding:12px; background:rgba(255,255,255,.05); box-shadow:0 8px 24px rgba(0,0,0,.3); backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px)}
-.chat-messages{overflow-y:auto; padding:0; display:flex; flex-direction:column; gap:12px}
+.chat-window{display:flex; flex-direction:column; gap:12px; flex:1 1 auto; max-height:70vh; min-height:320px; border:1px solid rgba(255,255,255,.15); border-radius:20px; padding:12px; background:rgba(255,255,255,.05); box-shadow:0 8px 24px rgba(0,0,0,.3); backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px); overflow:hidden}
+.chat-messages{flex:1 1 auto; min-height:0; overflow-y:auto; padding:0; display:flex; flex-direction:column; gap:12px}
+#conversation{flex:1 1 auto; min-height:0; overflow-y:auto}
 .parent-list, #conversation, .chat-messages{ -ms-overflow-style:none; scrollbar-width:none }
 .parent-list::-webkit-scrollbar, #conversation::-webkit-scrollbar, .chat-messages::-webkit-scrollbar{ display:none }
 .chat-line{display:flex; align-items:flex-end; gap:8px}
@@ -2938,6 +2939,12 @@ section[data-route="/"] .steps .step:hover{
 .chat-reset{justify-self:end}
 .bubble{max-width:100%; padding:12px 16px; border-radius:20px; line-height:1.4; color:#ffffff}
 .bubble.assistant{background:rgba(255,255,255,.08); border:none}
+.chat-window .chat-messages{max-height:100%}
+@media(max-width:600px){
+  .chat-window{max-height:60vh; min-height:auto}
+  #conversation,
+  .chat-window .chat-messages{max-height:55vh}
+}
 .bubble.user{background:linear-gradient(135deg,var(--orange-strong),var(--violet-strong)); border:none; color:#000}
 .chat-messages .meta{font-size:11px; color:var(--muted); margin-bottom:2px}
 .chat-line.user .meta{text-align:right}

--- a/messages.html
+++ b/messages.html
@@ -17,10 +17,10 @@
     .parent-item time{display:block;font-size:.75rem;opacity:.7;color:var(--muted,#666)}
     .parent-item .del-btn{background:none;border:none;color:var(--muted,#666);cursor:pointer;padding:2px;margin-left:auto}
     .parent-item .del-btn:hover{color:#c00}
-    .chat-window{flex:1;display:none;flex-direction:column;height:100%}
+    .chat-window{display:none;flex-direction:column;flex:1 1 auto;max-height:70vh;min-height:320px}
     .chat-window.open{display:flex}
     .chat-placeholder{flex:1;display:flex;align-items:center;justify-content:center;height:100%;text-align:center}
-    #conversation{flex:1;overflow-y:auto}
+    #conversation{flex:1 1 auto;overflow-y:auto;min-height:0}
     /* Ensure my sent bubbles use solid black text */
     .chat-window .bubble.user{color:#000}
     /* Small green dot for unread conversations */
@@ -28,8 +28,9 @@
     @media(max-width:600px){
         .chat-area{flex-direction:column;height:auto}
         .parent-list{flex:0 0 auto;width:100%;max-height:30vh;height:auto}
-        .chat-window{flex:1 1 auto;width:100%;min-height:70vh;height:auto}
-        .chat-placeholder{flex:1 1 auto;width:100%;min-height:70vh;height:auto}
+        .chat-window{flex:1 1 auto;width:100%;max-height:60vh;min-height:auto}
+        .chat-placeholder{flex:1 1 auto;width:100%;min-height:60vh;height:auto}
+        #conversation{max-height:55vh}
       }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- cap the chat window height with a flex column layout and scrollable conversation content
- update the messaging page styles so the conversation remains within viewport constraints on desktop and mobile
- ensure the conversation view auto-scrolls after new messages are appended

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db16016a588321bdb249cd8d1bf5ce