### PR TITLE
Fix Google-authenticated name rendering in messaging UI

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7191,21 +7191,32 @@ const TIMELINE_MILESTONES = [
       const profileIdStr = profileId != null ? String(profileId) : '';
       const activeIdStr = activeId != null ? String(activeId) : '';
       const isSelf = profileIdStr && activeIdStr && profileIdStr === activeIdStr;
+      const rawFullName =
+        raw && typeof raw === 'object'
+          ? raw.full_name ?? raw.fullName ?? raw.name ?? ''
+          : '';
+      const sanitizedFullName = typeof rawFullName === 'string' ? rawFullName.trim() : '';
+      const normalizedName = sanitizedFullName || normalized.name || 'Utilisateur';
+      const authorMeta = {
+        ...normalized,
+        name: normalizedName,
+        fullName: sanitizedFullName,
+      };
       if (isSelf) {
         const localCount = resolveLocalChildCount();
         if (
           Number.isFinite(localCount)
-          && (localCount > 0 || !Number.isFinite(normalized.childCount))
+          && (localCount > 0 || !Number.isFinite(authorMeta.childCount))
         ) {
-          normalized.childCount = Math.max(0, Math.trunc(localCount));
+          authorMeta.childCount = Math.max(0, Math.trunc(localCount));
         }
         const localShow = resolveLocalShowChildrenPref();
         if (localShow != null) {
-          normalized.showChildCount = localShow;
+          authorMeta.showChildCount = localShow;
         }
       }
       return {
-        ...normalized,
+        ...authorMeta,
         profileId: profileIdStr || null,
         isSelf,
       };


### PR DESCRIPTION
## Summary
- add helper utilities to sanitize names, log Google-authenticated profiles, and use `full_name` in Supabase queries for the messaging UI
- ensure conversations store real Google profile names, only fall back to "Parent" when missing, and surface those names throughout the thread list and avatars
- keep community author metadata in sync with Supabase profile full names for authenticated users

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68db25b18bd48321934dc35c566d1eb8