### PR TITLE
Fix Google profile loading for messaging

### DIFF
--- a/assets/messages.js
+++ b/assets/messages.js
@@ -1058,7 +1058,9 @@ async function loadConversations(){
       console.debug('[profiles-by-ids response]', r);
       if (r.ok) {
         const j = await r.json();
-        profiles = (j.profiles||[])
+        const profilesData = j?.data?.profiles || [];
+        console.debug('[GoogleAuth] Profiles-by-ids renvoyés:', profilesData);
+        profiles = profilesData
           .map((p) => normalizeGoogleProfile(p, p?.id))
           .filter(Boolean);
       } else {
@@ -1153,7 +1155,9 @@ async function ensureConversation(otherId){
     console.debug('[profiles-by-ids response]', r);
     if (r.ok) {
       const j = await r.json();
-      const p = (j.profiles||[])[0];
+      const profiles = j?.data?.profiles || [];
+      console.debug('[GoogleAuth] Profiles-by-ids renvoyés:', profiles);
+      const p = (profiles||[])[0];
       const normalized = normalizeGoogleProfile(p, p?.id ?? id);
       if (normalized) profile = normalized;
     } else {


### PR DESCRIPTION
## Summary
- read profiles returned by the profiles-by-ids edge function from the nested data.profiles payload
- add debugging logs to verify Google-authenticated profiles are received correctly
- ensure conversations use the updated profile structure when normalizing names

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db2dee95e083219978471dd0004ca8