### PR TITLE
Fix chat windows initial sizing and scrolling

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2893,7 +2893,7 @@ section[data-route="/ai"] .card-header p{ text-align:center; }
   .ai-tool-copy h3{ font-size:17px; }
   .ai-tool-copy p{ font-size:13px; }
 }
-.chat-window{display:flex; flex-direction:column; gap:12px; flex:1 1 auto; max-height:70vh; min-height:320px; border:1px solid rgba(255,255,255,.15); border-radius:20px; padding:12px; background:rgba(255,255,255,.05); box-shadow:0 8px 24px rgba(0,0,0,.3); backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px); overflow:hidden}
+.chat-window{display:flex; flex-direction:column; gap:12px; flex:1 1 auto; height:70vh; min-height:60vh; max-height:70vh; border:1px solid rgba(255,255,255,.15); border-radius:20px; padding:12px; background:rgba(255,255,255,.05); box-shadow:0 8px 24px rgba(0,0,0,.3); backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px); overflow:hidden}
 .chat-messages{flex:1 1 auto; min-height:0; overflow-y:auto; padding:0; display:flex; flex-direction:column; gap:12px}
 #conversation{flex:1 1 auto; min-height:0; overflow-y:auto}
 .parent-list, #conversation, .chat-messages{ -ms-overflow-style:none; scrollbar-width:none }
@@ -2941,9 +2941,9 @@ section[data-route="/"] .steps .step:hover{
 .bubble.assistant{background:rgba(255,255,255,.08); border:none}
 .chat-window .chat-messages{max-height:100%}
 @media(max-width:600px){
-  .chat-window{max-height:60vh; min-height:auto}
+  .chat-window{height:60vh; min-height:60vh; max-height:60vh}
   #conversation,
-  .chat-window .chat-messages{max-height:55vh}
+  .chat-window .chat-messages{max-height:100%}
 }
 .bubble.user{background:linear-gradient(135deg,var(--orange-strong),var(--violet-strong)); border:none; color:#000}
 .chat-messages .meta{font-size:11px; color:var(--muted); margin-bottom:2px}

--- a/messages.html
+++ b/messages.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/png" href="/logoonly.png" />
   <link rel="stylesheet" href="assets/style.css?v=6" />
   <style>
-    .chat-area{display:flex;gap:20px;margin-top:20px;height:70vh;align-items:stretch}
+    .chat-area{display:flex;gap:20px;margin-top:20px;height:70vh;min-height:60vh;align-items:stretch}
     .parent-list{flex:0 0 250px;height:100%;overflow-y:auto}
     #parents-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:12px}
     .parent-item{display:flex;align-items:flex-start;gap:8px;padding:8px;cursor:pointer;border-radius:12px;width:100%}
@@ -17,20 +17,20 @@
     .parent-item time{display:block;font-size:.75rem;opacity:.7;color:var(--muted,#666)}
     .parent-item .del-btn{background:none;border:none;color:var(--muted,#666);cursor:pointer;padding:2px;margin-left:auto}
     .parent-item .del-btn:hover{color:#c00}
-    .chat-window{display:none;flex-direction:column;flex:1 1 auto;max-height:70vh;min-height:320px}
+    .chat-window{display:none;flex-direction:column;flex:1 1 auto;height:70vh;min-height:60vh;max-height:70vh}
     .chat-window.open{display:flex}
-    .chat-placeholder{flex:1;display:flex;align-items:center;justify-content:center;height:100%;text-align:center}
+    .chat-placeholder{flex:1;display:flex;align-items:center;justify-content:center;height:70vh;min-height:60vh;text-align:center}
     #conversation{flex:1 1 auto;overflow-y:auto;min-height:0}
     /* Ensure my sent bubbles use solid black text */
     .chat-window .bubble.user{color:#000}
     /* Small green dot for unread conversations */
     .dot-unread{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--ok,#2dc07a);box-shadow:0 0 0 2px rgba(255,255,255,.12)}
     @media(max-width:600px){
-        .chat-area{flex-direction:column;height:auto}
+        .chat-area{flex-direction:column;height:auto;min-height:60vh}
         .parent-list{flex:0 0 auto;width:100%;max-height:30vh;height:auto}
-        .chat-window{flex:1 1 auto;width:100%;max-height:60vh;min-height:auto}
-        .chat-placeholder{flex:1 1 auto;width:100%;min-height:60vh;height:auto}
-        #conversation{max-height:55vh}
+        .chat-window{flex:1 1 auto;width:100%;height:60vh;min-height:60vh;max-height:60vh}
+        .chat-placeholder{flex:1 1 auto;width:100%;min-height:60vh;height:60vh}
+        #conversation{max-height:100%}
       }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- set a consistent viewport-based height for chat windows so they load at full size on desktop and mobile
- ensure chat message panes scroll internally instead of expanding the outer container on both AI and private message pages

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db8dc0bf7c8321ba79e6a97af8284e