### PR TITLE
Remove duplicate heading in settings section

### DIFF
--- a/index.html
+++ b/index.html
@@ -860,7 +860,6 @@
                 <option value="anxieux">Anxieux / stressé</option>
               </select>
             </label>
-            <h3>Mises à jour parentales</h3>
             <label>Commentaire du parent (recommandé)
               <textarea name="parent_comment" rows="4" maxlength="2000" placeholder="Notez les éléments marquants ou votre ressenti du moment…"></textarea>
             </label>


### PR DESCRIPTION
## Summary
- remove the duplicate "Mises à jour parentales" heading from the settings form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dba7f85f3c83219e70cbfa1aa1238b