### PR TITLE
Enable Enter-to-send in AI and messaging chats

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -3635,6 +3635,25 @@ const TIMELINE_MILESTONES = [
           txtChat.placeholder = placeholders[idx];
         }
       }, 4000);
+      if (!txtChat.dataset.enterSubmitBound) {
+        txtChat.dataset.enterSubmitBound = '1';
+        txtChat.addEventListener('keydown', (event) => {
+          if (
+            event.key === 'Enter'
+            && !event.shiftKey
+            && !event.ctrlKey
+            && !event.metaKey
+            && !event.altKey
+          ) {
+            if (fChat?.dataset.busy === '1') return;
+            event.preventDefault();
+            const form = fChat;
+            if (!form) return;
+            if (typeof form.requestSubmit === 'function') form.requestSubmit();
+            else form.submit();
+          }
+        });
+      }
     }
     if (btnReset) {
       if (btnReset._aiClickHandler) {

--- a/assets/messages.js
+++ b/assets/messages.js
@@ -1350,6 +1350,26 @@ $('#message-form').addEventListener('submit', async e=>{
   renderParentList();
 });
 
+const messageTextarea = $('#message-input');
+if (messageTextarea && !messageTextarea.dataset.enterSubmitBound) {
+  messageTextarea.dataset.enterSubmitBound = '1';
+  messageTextarea.addEventListener('keydown', (event) => {
+    if (
+      event.key === 'Enter'
+      && !event.shiftKey
+      && !event.ctrlKey
+      && !event.metaKey
+      && !event.altKey
+    ) {
+      const form = $('#message-form');
+      if (!form || form.dataset.busy === '1') return;
+      event.preventDefault();
+      if (typeof form.requestSubmit === 'function') form.requestSubmit();
+      else form.submit();
+    }
+  });
+}
+
 function setupMessageSubscription(otherId){
   if (isAnon) { messagesChannel = null; return; }
   const id = idStr(otherId);


### PR DESCRIPTION
## Summary
- allow the AI chatbot textarea to submit on Enter without modifier keys
- enable Enter-to-send for the private messages textarea while preserving Shift+Enter for new lines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbb264e8b88321935c798f9321eb02