### PR TITLE
Add gradient dividers to Ped’IA flagship cards

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2258,6 +2258,7 @@ section[data-route="/"] .route-canvas{
 .flagship-card-num{position:relative; display:inline-flex; align-items:center; justify-content:center; width:100%; height:100%; font-weight:800; font-size:1.15rem; color:var(--orange-strong); letter-spacing:.08em; text-shadow:0 2px 10px rgba(255,140,60,.35); z-index:1}
 .flagship-card-num::before{content:""; position:absolute; inset:6px; border-radius:14px; background:radial-gradient(120% 120% at 20% 15%, rgba(255,190,140,.28), transparent 70%), linear-gradient(145deg, rgba(24,28,44,.92), rgba(14,16,26,.88)); box-shadow:0 12px 26px rgba(0,0,0,.38); opacity:.92; z-index:-1}
 .flagship-card h3{margin:0; font-size:clamp(18px,1.8vw,20px); font-weight:780; letter-spacing:.015em; color:var(--text)}
+.flagship-card h3::after{content:""; display:block; width:48px; height:2px; margin:8px 0 0; border-radius:999px; background:linear-gradient(90deg, var(--orange-strong), var(--blue-strong)); opacity:.85}
 .flagship-card p{margin:0; color:var(--muted); line-height:1.48; font-size:clamp(13px, 1vw, 15px)}
 @media(max-width:900px){
   .flagship-cards{


### PR DESCRIPTION
## Summary
- add a gradient divider below each flagship card title in the Ped’IA section to mirror the "Comment ça marche ?" styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0e2fc99c8321a95e8522aeb8c40e