### PR TITLE
Increase flagship image translucency

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2239,7 +2239,7 @@ section[data-route="/"] .route-canvas{
 .flagship-media{width:clamp(260px,46vw,560px); margin:0 auto; display:flex; justify-content:center}
 .flagship-image-wrap{position:relative; width:100%; border-radius:46px; overflow:hidden; padding:0; box-shadow:0 36px 90px rgba(0,0,0,.52); isolation:isolate}
 .flagship-image-wrap::before{content:""; position:absolute; inset:-18% -24% -20%; background:radial-gradient(125% 125% at 20% 15%, rgba(255,170,110,.44), transparent 70%), radial-gradient(125% 125% at 78% 10%, rgba(120,170,255,.4), transparent 74%); filter:blur(55px); opacity:.75; z-index:-1}
-.flagship-image{display:block; width:100%; height:auto; border-radius:inherit}
+.flagship-image{display:block; width:100%; height:auto; border-radius:inherit; opacity:.8}
 .flagship-cards{display:flex; gap:clamp(16px,2.4vw,28px); width:100%; overflow-x:auto; overflow-y:hidden; padding:4px clamp(18px,6vw,34px) 16px; scroll-snap-type:x mandatory; scroll-padding-inline:clamp(14px,4vw,28px); justify-content:flex-start; align-items:stretch; position:relative; margin:0 auto; touch-action:pan-x; overscroll-behavior-inline:contain; overscroll-behavior-block:none}
 .flagship-cards::before{content:""; position:absolute; inset:0; border-radius:40px; background:radial-gradient(120% 120% at 0% 0%, rgba(255,170,110,.12), transparent 70%); opacity:.5; pointer-events:none}
 .flagship-cards::-webkit-scrollbar{height:8px}


### PR DESCRIPTION
## Summary
- increase the opacity adjustment on the flagship section image to make it appear more translucent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc113f9df4832191c94c2eb768eb7b