### PR TITLE
Fix anonymous profile flows by relaying auth headers

### DIFF
--- a/api/edge/[...slug].js
+++ b/api/edge/[...slug].js
@@ -26,8 +26,19 @@ export default async function handler(req, res) {
   const headers = {
     'Content-Type': 'application/json',
     apikey: chosenKey,
-    Authorization: `Bearer ${chosenKey}`,
   };
+
+  const incomingAuthHeaderRaw = req?.headers?.authorization;
+  let incomingAuthHeader = '';
+  if (Array.isArray(incomingAuthHeaderRaw)) {
+    incomingAuthHeader = incomingAuthHeaderRaw.find(Boolean) || '';
+  } else if (typeof incomingAuthHeaderRaw === 'string') {
+    incomingAuthHeader = incomingAuthHeaderRaw;
+  }
+
+  if (incomingAuthHeader && incomingAuthHeader.trim()) {
+    headers.Authorization = incomingAuthHeader;
+  }
 
   const keyPreview = (chosenKey || '').slice(0, 20);
   const safeHeaders = Object.fromEntries(

--- a/assets/app.js
+++ b/assets/app.js
@@ -2915,7 +2915,7 @@ const TIMELINE_MILESTONES = [
       const fullNameRaw = typeof currentUser?.pseudo === 'string' ? currentUser.pseudo.trim() : '';
       const requestBody = fullNameRaw ? { fullName: fullNameRaw } : {};
       const payload = await callEdgeFunction('profiles-create-anon', { body: requestBody });
-      const data = payload?.profile;
+      const data = payload?.profile || payload?.data?.profile || null;
       if (!data) {
         throw new Error('Création impossible pour le moment.');
       }

--- a/assets/messages.js
+++ b/assets/messages.js
@@ -106,7 +106,7 @@ async function ensureSupabase(){
 async function fetchAnonProfileByCode(rawCode) {
   const code = typeof rawCode === 'string' ? rawCode.trim().toUpperCase() : '';
   if (!code) throw new Error('Code unique manquant.');
-  const response = await fetch('/api/anon/parent-updates', {
+  const response = await fetch('/api/edge/anon-parent-updates', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'profile', code })
@@ -177,13 +177,14 @@ async function createAnonymousProfile(){
     });
     let responsePayload = null;
     try { responsePayload = await response.json(); } catch (e) { responsePayload = null; }
-    if (!response.ok || !responsePayload?.profile) {
+    const profile = responsePayload?.data?.profile || responsePayload?.profile || null;
+    if (!response.ok || !profile) {
       const msg = responsePayload?.error || 'Création impossible pour le moment.';
       const err = new Error(msg);
       if (responsePayload?.details) err.details = responsePayload.details;
       throw err;
     }
-    const data = responsePayload.profile;
+    const data = profile;
     if (status) {
       status.classList.remove('error');
       status.innerHTML = `Ton code unique&nbsp;: <strong>${data.code_unique}</strong>.<br>Garde-le précieusement et saisis-le juste en dessous dans «&nbsp;Se connecter avec un code&nbsp;».`;


### PR DESCRIPTION
## Summary
- stop forcing the Supabase key into the Authorization header in the /api/edge proxy so edge functions can fall back to code-based auth
- make the main SPA tolerant of the data.profile payload returned by profiles-create-anon
- align the standalone messages page with the edge proxy and payload structure expected by Supabase functions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc71339bc83219c4e17ece5f6b18f