### PR TITLE
fix(edge-auth): update edge proxy and client auth handling

### DIFF
--- a/scripts/smoke-edge.sh
+++ b/scripts/smoke-edge.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE="${BASE:-https://synapkids.com}"
+
+echo "== Create anon =="
+curl -s -i "$BASE/api/edge/profiles-create-anon" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"create"}' | sed -n '1,10p'
+
+echo
+echo "== Login by code (replace CODE) =="
+CODE="${CODE:-A1B2-C3D4-E5F6}"
+curl -s -i "$BASE/api/edge/anon-parent-updates" \
+  -H "Content-Type: application/json" \
+  -d "{\"action\":\"profile\",\"code\":\"$CODE\"}" | sed -n '1,12p'
+
+echo
+echo "== Likes get (replace reply id & CODE) =="
+RID="${RID:-00000000-0000-0000-0000-000000000000}"
+curl -s -i "$BASE/api/edge/likes-get" \
+  -H "Content-Type: application/json" \
+  -d "{\"action\":\"list-by-reply-ids\",\"ids\":[\"$RID\"],\"code\":\"$CODE\"}" | sed -n '1,12p'

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,19 @@
+// supabase/functions/_shared/auth.ts
+export function readClientJwt(req: Request): string | null {
+  const h = req.headers.get('x-client-authorization') || '';
+  const m = /^Bearer\s+(.+)$/.exec(h);
+  return m ? m[1] : null;
+}
+
+export type UserContext =
+  | { kind: 'jwt'; jwt: string }
+  | { kind: 'code'; code: string }
+  | { kind: 'anonymous' };
+
+export async function resolveUserContext(req: Request, body: any): Promise<UserContext> {
+  const jwt = readClientJwt(req);
+  if (jwt) return { kind: 'jwt', jwt };
+  const code = body?.code ?? body?.anonCode ?? null;
+  if (code) return { kind: 'code', code };
+  return { kind: 'anonymous' };
+}

--- a/supabase/functions/anon-children/index.ts
+++ b/supabase/functions/anon-children/index.ts
@@ -1,10 +1,11 @@
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { HttpError } from "../_shared/anon-children.ts";
 import { processAnonChildrenRequest } from "../_shared/anon-children.ts";
+import { resolveUserContext } from "../_shared/auth.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Client-Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",
 };
 
@@ -31,12 +32,27 @@ function formatResult(status: number, body: Record<string, unknown> | null) {
 }
 
 serve(async (req) => {
-  try {
-    const body = await req.clone().json();
-    console.log("📥 anon-children received body:", body);
-  } catch (_err) {
-    console.log("📥 anon-children: no JSON body or invalid JSON");
+  let parseError = false;
+  const rawBody =
+    req.method === "POST"
+      ? await req.json().catch(() => {
+          parseError = true;
+          return {};
+        })
+      : {};
+  const baseBody = rawBody && typeof rawBody === "object" ? (rawBody as Record<string, unknown>) : {};
+  const hasValidBody = !parseError && (req.method !== "POST" || typeof rawBody === "object");
+  const ctx = await resolveUserContext(req, baseBody);
+  const payload: Record<string, unknown> = { ...baseBody };
+  if (ctx.kind === "code" && typeof payload.code !== "string" && typeof payload.anonCode !== "string") {
+    payload.code = ctx.code;
   }
+  console.log("[anon-children] request", {
+    method: req.method,
+    action: typeof payload.action === "string" ? payload.action : null,
+    ctxKind: ctx.kind,
+    hasCode: typeof payload.code === "string",
+  });
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
@@ -44,18 +60,18 @@ serve(async (req) => {
     return jsonResponse({ error: "Method Not Allowed" }, 405);
   }
   try {
-    const payload = await req.json().catch(() => {
+    if (!hasValidBody) {
       throw new HttpError(400, "Invalid JSON body");
-    });
+    }
     const result = await processAnonChildrenRequest(payload ?? {});
     return formatResult(result?.status ?? 200, (result?.body as Record<string, unknown>) ?? {});
   } catch (error) {
     const status = error instanceof HttpError ? error.status || 400 : 500;
     const message = error instanceof HttpError ? error.message : "Server error";
     const details = error instanceof HttpError ? error.details : error instanceof Error ? error.message : undefined;
-    console.error("[anon-children] error", { status, message, details, error });
-    const payload: Record<string, unknown> = { error: message };
-    if (details) payload.details = details;
-    return jsonResponse(payload, status);
+    console.error("[anon-children] error", { status, message, hasCode: ctx.kind === "code", error: String(details ?? message) });
+    const response: Record<string, unknown> = { error: message };
+    if (details) response.details = details;
+    return jsonResponse(response, status);
   }
 });

--- a/supabase/functions/anon-community/index.ts
+++ b/supabase/functions/anon-community/index.ts
@@ -3,10 +3,11 @@
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { HttpError } from "../_shared/anon-children.ts";
 import { processAnonCommunityRequest } from "../_shared/anon-community.ts";
+import { resolveUserContext } from "../_shared/auth.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Client-Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",
 };
 
@@ -33,6 +34,27 @@ function formatResult(status: number, body: Record<string, unknown> | null) {
 }
 
 serve(async (req) => {
+  let parseError = false;
+  const rawBody =
+    req.method === "POST"
+      ? await req.json().catch(() => {
+          parseError = true;
+          return {};
+        })
+      : {};
+  const baseBody = rawBody && typeof rawBody === "object" ? (rawBody as Record<string, unknown>) : {};
+  const hasValidBody = !parseError && (req.method !== "POST" || typeof rawBody === "object");
+  const ctx = await resolveUserContext(req, baseBody);
+  const payload: Record<string, unknown> = { ...baseBody };
+  if (ctx.kind === "code" && typeof payload.code !== "string" && typeof payload.anonCode !== "string") {
+    payload.code = ctx.code;
+  }
+  console.log("[anon-community] request", {
+    method: req.method,
+    action: typeof payload.action === "string" ? payload.action : null,
+    ctxKind: ctx.kind,
+    hasCode: typeof payload.code === "string",
+  });
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
@@ -40,18 +62,18 @@ serve(async (req) => {
     return jsonResponse({ error: "Method Not Allowed" }, 405);
   }
   try {
-    const payload = await req.json().catch(() => {
+    if (!hasValidBody) {
       throw new HttpError(400, "Invalid JSON body");
-    });
+    }
     const result = await processAnonCommunityRequest(payload ?? {});
     return formatResult(result?.status ?? 200, (result?.body as Record<string, unknown>) ?? {});
   } catch (error) {
     const status = error instanceof HttpError ? error.status || 400 : 500;
     const message = error instanceof HttpError ? error.message : "Server error";
     const details = error instanceof HttpError ? error.details : error instanceof Error ? error.message : undefined;
-    console.error("[anon-community] error", { status, message, details, error });
-    const payload: Record<string, unknown> = { error: message };
-    if (details) payload.details = details;
-    return jsonResponse(payload, status);
+    console.error("[anon-community] error", { status, message, hasCode: ctx.kind === "code", error: String(details ?? message) });
+    const response: Record<string, unknown> = { error: message };
+    if (details) response.details = details;
+    return jsonResponse(response, status);
   }
 });

--- a/supabase/functions/anon-family/index.ts
+++ b/supabase/functions/anon-family/index.ts
@@ -1,10 +1,11 @@
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { HttpError } from "../_shared/anon-children.ts";
 import { processAnonFamilyRequest } from "../_shared/anon-family.ts";
+import { resolveUserContext } from "../_shared/auth.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Client-Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",
 };
 
@@ -31,6 +32,27 @@ function formatResult(status: number, body: Record<string, unknown> | null) {
 }
 
 serve(async (req) => {
+  let parseError = false;
+  const rawBody =
+    req.method === "POST"
+      ? await req.json().catch(() => {
+          parseError = true;
+          return {};
+        })
+      : {};
+  const baseBody = rawBody && typeof rawBody === "object" ? (rawBody as Record<string, unknown>) : {};
+  const hasValidBody = !parseError && (req.method !== "POST" || typeof rawBody === "object");
+  const ctx = await resolveUserContext(req, baseBody);
+  const payload: Record<string, unknown> = { ...baseBody };
+  if (ctx.kind === "code" && typeof payload.code !== "string" && typeof payload.anonCode !== "string") {
+    payload.code = ctx.code;
+  }
+  console.log("[anon-family] request", {
+    method: req.method,
+    action: typeof payload.action === "string" ? payload.action : null,
+    ctxKind: ctx.kind,
+    hasCode: typeof payload.code === "string",
+  });
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
@@ -38,18 +60,18 @@ serve(async (req) => {
     return jsonResponse({ error: "Method Not Allowed" }, 405);
   }
   try {
-    const payload = await req.json().catch(() => {
+    if (!hasValidBody) {
       throw new HttpError(400, "Invalid JSON body");
-    });
+    }
     const result = await processAnonFamilyRequest(payload ?? {});
     return formatResult(result?.status ?? 200, (result?.body as Record<string, unknown>) ?? {});
   } catch (error) {
     const status = error instanceof HttpError ? error.status || 400 : 500;
     const message = error instanceof HttpError ? error.message : "Server error";
     const details = error instanceof HttpError ? error.details : error instanceof Error ? error.message : undefined;
-    console.error("[anon-family] error", { status, message, details, error });
-    const payload: Record<string, unknown> = { error: message };
-    if (details) payload.details = details;
-    return jsonResponse(payload, status);
+    console.error("[anon-family] error", { status, message, hasCode: ctx.kind === "code", error: String(details ?? message) });
+    const response: Record<string, unknown> = { error: message };
+    if (details) response.details = details;
+    return jsonResponse(response, status);
   }
 });

--- a/supabase/functions/anon-messages/index.ts
+++ b/supabase/functions/anon-messages/index.ts
@@ -1,10 +1,11 @@
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { HttpError } from "../_shared/anon-children.ts";
 import { processAnonMessagesRequest } from "../_shared/anon-messages.ts";
+import { resolveUserContext } from "../_shared/auth.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Client-Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",
 };
 
@@ -31,6 +32,27 @@ function formatResult(status: number, body: Record<string, unknown> | null) {
 }
 
 serve(async (req) => {
+  let parseError = false;
+  const rawBody =
+    req.method === "POST"
+      ? await req.json().catch(() => {
+          parseError = true;
+          return {};
+        })
+      : {};
+  const baseBody = rawBody && typeof rawBody === "object" ? (rawBody as Record<string, unknown>) : {};
+  const hasValidBody = !parseError && (req.method !== "POST" || typeof rawBody === "object");
+  const ctx = await resolveUserContext(req, baseBody);
+  const payload: Record<string, unknown> = { ...baseBody };
+  if (ctx.kind === "code" && typeof payload.code !== "string" && typeof payload.anonCode !== "string") {
+    payload.code = ctx.code;
+  }
+  console.log("[anon-messages] request", {
+    method: req.method,
+    action: typeof payload.action === "string" ? payload.action : null,
+    ctxKind: ctx.kind,
+    hasCode: typeof payload.code === "string",
+  });
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
@@ -38,18 +60,18 @@ serve(async (req) => {
     return jsonResponse({ error: "Method Not Allowed" }, 405);
   }
   try {
-    const payload = await req.json().catch(() => {
+    if (!hasValidBody) {
       throw new HttpError(400, "Invalid JSON body");
-    });
+    }
     const result = await processAnonMessagesRequest(payload ?? {});
     return formatResult(result?.status ?? 200, (result?.body as Record<string, unknown>) ?? {});
   } catch (error) {
     const status = error instanceof HttpError ? error.status || 400 : 500;
     const message = error instanceof HttpError ? error.message : "Server error";
     const details = error instanceof HttpError ? error.details : error instanceof Error ? error.message : undefined;
-    console.error("[anon-messages] error", { status, message, details, error });
-    const payload: Record<string, unknown> = { error: message };
-    if (details) payload.details = details;
-    return jsonResponse(payload, status);
+    console.error("[anon-messages] error", { status, message, hasCode: ctx.kind === "code", error: String(details ?? message) });
+    const response: Record<string, unknown> = { error: message };
+    if (details) response.details = details;
+    return jsonResponse(response, status);
   }
 });

--- a/supabase/functions/anon-parent-updates/index.ts
+++ b/supabase/functions/anon-parent-updates/index.ts
@@ -1,10 +1,11 @@
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { HttpError } from "../_shared/anon-children.ts";
 import { processAnonParentUpdatesRequest } from "../_shared/anon-parent-updates.ts";
+import { resolveUserContext } from "../_shared/auth.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Client-Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",
 };
 
@@ -31,6 +32,27 @@ function formatResult(status: number, body: Record<string, unknown> | null) {
 }
 
 serve(async (req) => {
+  let parseError = false;
+  const rawBody =
+    req.method === "POST"
+      ? await req.json().catch(() => {
+          parseError = true;
+          return {};
+        })
+      : {};
+  const baseBody = rawBody && typeof rawBody === "object" ? (rawBody as Record<string, unknown>) : {};
+  const hasValidBody = !parseError && (req.method !== "POST" || typeof rawBody === "object");
+  const ctx = await resolveUserContext(req, baseBody);
+  const payload: Record<string, unknown> = { ...baseBody };
+  if (ctx.kind === "code" && typeof payload.code !== "string" && typeof payload.anonCode !== "string") {
+    payload.code = ctx.code;
+  }
+  console.log("[anon-parent-updates] request", {
+    method: req.method,
+    action: typeof payload.action === "string" ? payload.action : null,
+    ctxKind: ctx.kind,
+    hasCode: typeof payload.code === "string",
+  });
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
@@ -38,18 +60,18 @@ serve(async (req) => {
     return jsonResponse({ error: "Method Not Allowed" }, 405);
   }
   try {
-    const payload = await req.json().catch(() => {
+    if (!hasValidBody) {
       throw new HttpError(400, "Invalid JSON body");
-    });
+    }
     const result = await processAnonParentUpdatesRequest(payload ?? {});
     return formatResult(result?.status ?? 200, (result?.body as Record<string, unknown>) ?? {});
   } catch (error) {
     const status = error instanceof HttpError ? error.status || 400 : 500;
     const message = error instanceof HttpError ? error.message : "Server error";
     const details = error instanceof HttpError ? error.details : error instanceof Error ? error.message : undefined;
-    console.error("[anon-parent-updates] error", { status, message, details, error });
-    const payload: Record<string, unknown> = { error: message };
-    if (details) payload.details = details;
-    return jsonResponse(payload, status);
+    console.error("[anon-parent-updates] error", { status, message, hasCode: ctx.kind === "code", error: String(details ?? message) });
+    const response: Record<string, unknown> = { error: message };
+    if (details) response.details = details;
+    return jsonResponse(response, status);
   }
 });

--- a/supabase/functions/child-updates/index.ts
+++ b/supabase/functions/child-updates/index.ts
@@ -13,7 +13,7 @@ if (!supabaseUrl || !serviceKey) {
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Client-Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",
 };
 

--- a/supabase/functions/likes-add/index.ts
+++ b/supabase/functions/likes-add/index.ts
@@ -1,11 +1,18 @@
 // @ts-nocheck
 
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
-import { HttpError, supabaseRequest } from "../_shared/anon-children.ts";
-import { resolveUserContext, fetchLikeCount } from "../_shared/likes-helpers.ts";
+import {
+  HttpError,
+  fetchAnonProfile,
+  normalizeCode,
+  supabaseRequest,
+} from "../_shared/anon-children.ts";
+import { fetchLikeCount } from "../_shared/likes-helpers.ts";
+import { resolveUserContext, type UserContext } from "../_shared/auth.ts";
 
 const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? Deno.env.get("NEXT_PUBLIC_SUPABASE_URL") ?? "";
 const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? Deno.env.get("SUPABASE_SERVICE_KEY") ?? "";
+const anonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? Deno.env.get("NEXT_PUBLIC_SUPABASE_ANON_KEY") ?? "";
 
 if (!supabaseUrl || !serviceKey) {
   console.error("[likes-add] Missing Supabase configuration");
@@ -13,7 +20,7 @@ if (!supabaseUrl || !serviceKey) {
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Client-Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",
 };
 
@@ -27,7 +34,75 @@ function jsonResponse(body: Record<string, unknown>, status = 200) {
   });
 }
 
+async function fetchUserIdFromJwt(jwt: string): Promise<string> {
+  if (!supabaseUrl || !serviceKey) {
+    throw new HttpError(500, "Server misconfigured");
+  }
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${jwt}`,
+  };
+  const apiKey = anonKey || serviceKey;
+  if (apiKey) headers.apikey = apiKey;
+  const response = await fetch(`${supabaseUrl}/auth/v1/user`, { headers });
+  if (!response.ok) {
+    const status = response.status === 401 ? 401 : 400;
+    throw new HttpError(status, "Invalid token");
+  }
+  const data = await response.json().catch(() => null);
+  const userId = data?.id ?? data?.user?.id ?? "";
+  const trimmed = typeof userId === "string" ? userId.trim() : "";
+  if (!trimmed) {
+    throw new HttpError(401, "Invalid token");
+  }
+  return trimmed;
+}
+
+async function resolveLikeContext(ctx: UserContext) {
+  if (!supabaseUrl || !serviceKey) {
+    throw new HttpError(500, "Server misconfigured");
+  }
+  const headers = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+  };
+  if (ctx.kind === "jwt") {
+    const userId = await fetchUserIdFromJwt(ctx.jwt);
+    return { supaUrl: supabaseUrl, headers, userId };
+  }
+  if (ctx.kind === "code") {
+    const code = normalizeCode(ctx.code);
+    if (!code) {
+      throw new HttpError(400, "code required");
+    }
+    const profile = await fetchAnonProfile(supabaseUrl, serviceKey, code);
+    const profileId = profile?.id != null ? String(profile.id).trim() : "";
+    if (!profileId) {
+      throw new HttpError(404, "Profile not found");
+    }
+    return { supaUrl: supabaseUrl, headers, userId: profileId };
+  }
+  throw new HttpError(400, "code or token required");
+}
+
 serve(async (req) => {
+  let parseError = false;
+  const rawBody =
+    req.method === "POST"
+      ? await req.json().catch(() => {
+          parseError = true;
+          return {};
+        })
+      : {};
+  const body = rawBody && typeof rawBody === "object" ? (rawBody as Record<string, unknown>) : {};
+  const hasValidBody = !parseError && (req.method !== "POST" || typeof rawBody === "object");
+  const hasBody = Object.keys(body).length > 0;
+  const ctx = await resolveUserContext(req, body);
+  console.log("[likes-add] request", {
+    method: req.method,
+    hasBody,
+    ctxKind: ctx.kind,
+    hasCode: ctx.kind === "code",
+  });
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
@@ -35,26 +110,11 @@ serve(async (req) => {
     return jsonResponse({ error: "Method Not Allowed" }, 405);
   }
   try {
-    const context = await resolveUserContext(req);
-    if (context?.error) {
-      const status = context.error.status ?? 400;
-      return new Response(JSON.stringify(context.error), {
-        status,
-        headers: { ...corsHeaders, "Content-Type": "application/json; charset=utf-8" },
-      });
-    }
-    console.log('[resolveUserContext] likes-add', {
-      userId: context.userId,
-      mode: context.mode,
-      anon: context.anon ?? false,
-    });
-    const body = await req.json().catch(() => {
+    if (!hasValidBody) {
       throw new HttpError(400, "Invalid JSON body");
-    });
-    if (!supabaseUrl || !serviceKey) {
-      throw new HttpError(500, "Server misconfigured");
     }
-    const rawReplyId = body?.replyId ?? body?.reply_id;
+    const context = await resolveLikeContext(ctx);
+    const rawReplyId = (body as Record<string, unknown>)?.replyId ?? (body as Record<string, unknown>)?.reply_id;
     const replyId = rawReplyId != null ? String(rawReplyId).trim() : "";
     if (!replyId) {
       throw new HttpError(400, "replyId required");
@@ -74,7 +134,7 @@ serve(async (req) => {
     const status = error instanceof HttpError ? error.status || 400 : 500;
     const message = error instanceof HttpError ? error.message : "Server error";
     const details = error instanceof HttpError ? error.details : undefined;
-    console.error("[likes-add] error", { status, message, details, error });
+    console.error("[likes-add] error", { status, message, hasCode: ctx.kind === "code", error: String(details ?? message) });
     return jsonResponse({ error: message, details }, status);
   }
 });

--- a/supabase/functions/likes-get/index.ts
+++ b/supabase/functions/likes-get/index.ts
@@ -1,11 +1,17 @@
 // @ts-nocheck
 
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
-import { HttpError, supabaseRequest } from "../_shared/anon-children.ts";
-import { resolveUserContext } from "../_shared/likes-helpers.ts";
+import {
+  HttpError,
+  fetchAnonProfile,
+  normalizeCode,
+  supabaseRequest,
+} from "../_shared/anon-children.ts";
+import { resolveUserContext, type UserContext } from "../_shared/auth.ts";
 
 const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? Deno.env.get("NEXT_PUBLIC_SUPABASE_URL") ?? "";
 const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? Deno.env.get("SUPABASE_SERVICE_KEY") ?? "";
+const anonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? Deno.env.get("NEXT_PUBLIC_SUPABASE_ANON_KEY") ?? "";
 
 if (!supabaseUrl || !serviceKey) {
   console.error("[likes-get] Missing Supabase configuration");
@@ -13,7 +19,7 @@ if (!supabaseUrl || !serviceKey) {
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Client-Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",
 };
 
@@ -27,13 +33,75 @@ function jsonResponse(body: Record<string, unknown>, status = 200) {
   });
 }
 
-serve(async (req) => {
-  try {
-    const body = await req.clone().json();
-    console.log("📥 likes-get received body:", body);
-  } catch (_err) {
-    console.log("📥 likes-get: no JSON body or invalid JSON");
+async function fetchUserIdFromJwt(jwt: string): Promise<string> {
+  if (!supabaseUrl || !serviceKey) {
+    throw new HttpError(500, "Server misconfigured");
   }
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${jwt}`,
+  };
+  const apiKey = anonKey || serviceKey;
+  if (apiKey) headers.apikey = apiKey;
+  const response = await fetch(`${supabaseUrl}/auth/v1/user`, { headers });
+  if (!response.ok) {
+    const status = response.status === 401 ? 401 : 400;
+    throw new HttpError(status, "Invalid token");
+  }
+  const data = await response.json().catch(() => null);
+  const userId = data?.id ?? data?.user?.id ?? "";
+  const trimmed = typeof userId === "string" ? userId.trim() : "";
+  if (!trimmed) {
+    throw new HttpError(401, "Invalid token");
+  }
+  return trimmed;
+}
+
+async function resolveLikeContext(ctx: UserContext) {
+  if (!supabaseUrl || !serviceKey) {
+    throw new HttpError(500, "Server misconfigured");
+  }
+  const headers = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+  };
+  if (ctx.kind === "jwt") {
+    const userId = await fetchUserIdFromJwt(ctx.jwt);
+    return { supaUrl: supabaseUrl, headers, userId };
+  }
+  if (ctx.kind === "code") {
+    const code = normalizeCode(ctx.code);
+    if (!code) {
+      throw new HttpError(400, "code required");
+    }
+    const profile = await fetchAnonProfile(supabaseUrl, serviceKey, code);
+    const profileId = profile?.id != null ? String(profile.id).trim() : "";
+    if (!profileId) {
+      throw new HttpError(404, "Profile not found");
+    }
+    return { supaUrl: supabaseUrl, headers, userId: profileId };
+  }
+  throw new HttpError(400, "code or token required");
+}
+
+serve(async (req) => {
+  let parseError = false;
+  const rawBody =
+    req.method === "POST"
+      ? await req.json().catch(() => {
+          parseError = true;
+          return {};
+        })
+      : {};
+  const body = rawBody && typeof rawBody === "object" ? (rawBody as Record<string, unknown>) : {};
+  const hasValidBody = !parseError && (req.method !== "POST" || typeof rawBody === "object");
+  const hasBody = Object.keys(body).length > 0;
+  const ctx = await resolveUserContext(req, body);
+  console.log("[likes-get] request", {
+    method: req.method,
+    hasBody,
+    ctxKind: ctx.kind,
+    hasCode: ctx.kind === "code",
+  });
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
@@ -41,28 +109,15 @@ serve(async (req) => {
     return jsonResponse({ error: "Method Not Allowed" }, 405);
   }
   try {
-    const context = await resolveUserContext(req);
-    if (context?.error) {
-      const status = context.error.status ?? 400;
-      return new Response(JSON.stringify(context.error), {
-        status,
-        headers: { ...corsHeaders, "Content-Type": "application/json; charset=utf-8" },
-      });
-    }
-    console.log('[resolveUserContext] likes-get', {
-      userId: context.userId,
-      mode: context.mode,
-      anon: context.anon ?? false,
-    });
-    const body = await req.json().catch(() => {
+    if (!hasValidBody) {
       throw new HttpError(400, "Invalid JSON body");
-    });
-    if (!supabaseUrl || !serviceKey) {
-      throw new HttpError(500, "Server misconfigured");
     }
+    const context = await resolveLikeContext(ctx);
     const replyIdsRaw = Array.isArray(body?.replyIds)
       ? body.replyIds
-      : Array.isArray(body?.reply_ids) ? body.reply_ids : [];
+      : Array.isArray(body?.reply_ids)
+        ? body.reply_ids
+        : [];
     const replyIds = replyIdsRaw
       .map((value) => (value != null ? String(value).trim() : ""))
       .filter((value) => Boolean(value));
@@ -98,7 +153,7 @@ serve(async (req) => {
     const status = error instanceof HttpError ? error.status || 400 : 500;
     const message = error instanceof HttpError ? error.message : "Server error";
     const details = error instanceof HttpError ? error.details : undefined;
-    console.error("[likes-get] error", { status, message, details, error });
+    console.error("[likes-get] error", { status, message, hasCode: ctx.kind === "code", error: String(details ?? message) });
     return jsonResponse({ error: message, details }, status);
   }
 });

--- a/supabase/functions/likes-remove/index.ts
+++ b/supabase/functions/likes-remove/index.ts
@@ -1,11 +1,18 @@
 // @ts-nocheck
 
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
-import { HttpError, supabaseRequest } from "../_shared/anon-children.ts";
-import { resolveUserContext, fetchLikeCount } from "../_shared/likes-helpers.ts";
+import {
+  HttpError,
+  fetchAnonProfile,
+  normalizeCode,
+  supabaseRequest,
+} from "../_shared/anon-children.ts";
+import { fetchLikeCount } from "../_shared/likes-helpers.ts";
+import { resolveUserContext, type UserContext } from "../_shared/auth.ts";
 
 const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? Deno.env.get("NEXT_PUBLIC_SUPABASE_URL") ?? "";
 const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? Deno.env.get("SUPABASE_SERVICE_KEY") ?? "";
+const anonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? Deno.env.get("NEXT_PUBLIC_SUPABASE_ANON_KEY") ?? "";
 
 if (!supabaseUrl || !serviceKey) {
   console.error("[likes-remove] Missing Supabase configuration");
@@ -13,7 +20,7 @@ if (!supabaseUrl || !serviceKey) {
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Client-Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",
 };
 
@@ -27,7 +34,75 @@ function jsonResponse(body: Record<string, unknown>, status = 200) {
   });
 }
 
+async function fetchUserIdFromJwt(jwt: string): Promise<string> {
+  if (!supabaseUrl || !serviceKey) {
+    throw new HttpError(500, "Server misconfigured");
+  }
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${jwt}`,
+  };
+  const apiKey = anonKey || serviceKey;
+  if (apiKey) headers.apikey = apiKey;
+  const response = await fetch(`${supabaseUrl}/auth/v1/user`, { headers });
+  if (!response.ok) {
+    const status = response.status === 401 ? 401 : 400;
+    throw new HttpError(status, "Invalid token");
+  }
+  const data = await response.json().catch(() => null);
+  const userId = data?.id ?? data?.user?.id ?? "";
+  const trimmed = typeof userId === "string" ? userId.trim() : "";
+  if (!trimmed) {
+    throw new HttpError(401, "Invalid token");
+  }
+  return trimmed;
+}
+
+async function resolveLikeContext(ctx: UserContext) {
+  if (!supabaseUrl || !serviceKey) {
+    throw new HttpError(500, "Server misconfigured");
+  }
+  const headers = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+  };
+  if (ctx.kind === "jwt") {
+    const userId = await fetchUserIdFromJwt(ctx.jwt);
+    return { supaUrl: supabaseUrl, headers, userId };
+  }
+  if (ctx.kind === "code") {
+    const code = normalizeCode(ctx.code);
+    if (!code) {
+      throw new HttpError(400, "code required");
+    }
+    const profile = await fetchAnonProfile(supabaseUrl, serviceKey, code);
+    const profileId = profile?.id != null ? String(profile.id).trim() : "";
+    if (!profileId) {
+      throw new HttpError(404, "Profile not found");
+    }
+    return { supaUrl: supabaseUrl, headers, userId: profileId };
+  }
+  throw new HttpError(400, "code or token required");
+}
+
 serve(async (req) => {
+  let parseError = false;
+  const rawBody =
+    req.method === "POST"
+      ? await req.json().catch(() => {
+          parseError = true;
+          return {};
+        })
+      : {};
+  const body = rawBody && typeof rawBody === "object" ? (rawBody as Record<string, unknown>) : {};
+  const hasValidBody = !parseError && (req.method !== "POST" || typeof rawBody === "object");
+  const hasBody = Object.keys(body).length > 0;
+  const ctx = await resolveUserContext(req, body);
+  console.log("[likes-remove] request", {
+    method: req.method,
+    hasBody,
+    ctxKind: ctx.kind,
+    hasCode: ctx.kind === "code",
+  });
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
@@ -35,26 +110,11 @@ serve(async (req) => {
     return jsonResponse({ error: "Method Not Allowed" }, 405);
   }
   try {
-    const context = await resolveUserContext(req);
-    if (context?.error) {
-      const status = context.error.status ?? 400;
-      return new Response(JSON.stringify(context.error), {
-        status,
-        headers: { ...corsHeaders, "Content-Type": "application/json; charset=utf-8" },
-      });
-    }
-    console.log('[resolveUserContext] likes-remove', {
-      userId: context.userId,
-      mode: context.mode,
-      anon: context.anon ?? false,
-    });
-    const body = await req.json().catch(() => {
+    if (!hasValidBody) {
       throw new HttpError(400, "Invalid JSON body");
-    });
-    if (!supabaseUrl || !serviceKey) {
-      throw new HttpError(500, "Server misconfigured");
     }
-    const rawReplyId = body?.replyId ?? body?.reply_id;
+    const context = await resolveLikeContext(ctx);
+    const rawReplyId = (body as Record<string, unknown>)?.replyId ?? (body as Record<string, unknown>)?.reply_id;
     const replyId = rawReplyId != null ? String(rawReplyId).trim() : "";
     if (!replyId) {
       throw new HttpError(400, "replyId required");
@@ -72,7 +132,7 @@ serve(async (req) => {
     const status = error instanceof HttpError ? error.status || 400 : 500;
     const message = error instanceof HttpError ? error.message : "Server error";
     const details = error instanceof HttpError ? error.details : undefined;
-    console.error("[likes-remove] error", { status, message, details, error });
+    console.error("[likes-remove] error", { status, message, hasCode: ctx.kind === "code", error: String(details ?? message) });
     return jsonResponse({ error: message, details }, status);
   }
 });

--- a/supabase/functions/messages-delete-conversation/index.ts
+++ b/supabase/functions/messages-delete-conversation/index.ts
@@ -24,7 +24,7 @@ const supabaseAdmin = createClient(supabaseUrl, serviceKey, {
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Client-Authorization",
   "Access-Control-Allow-Methods": "POST,OPTIONS",
 };
 


### PR DESCRIPTION
## Summary
- replace the edge proxy handler to forward Supabase invocation keys, move client JWTs into X-Client-Authorization, and add a shared auth helper for functions
- update anonymous and likes Supabase functions to use the new helper, accept anon codes without JWTs, and normalise request parsing/logging
- adjust client helpers to send JWTs via X-Client-Authorization only, update callEdgeFunction consumers, and add a smoke test script for the new flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcd41306388321b113b3c033c6e41e