### PR TITLE
Add login redirect when no session or anon code

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -214,6 +214,13 @@ const TIMELINE_MILESTONES = [
     if (value == null) return '';
     return String(value).trim().toUpperCase();
   };
+  function hasAnonCode() {
+    try {
+      return !!localStorage.getItem('anonCode');
+    } catch (e) {
+      return false;
+    }
+  }
   const growthStatusState = {
     cache: new Map(),
     pending: new Map(),
@@ -1324,6 +1331,17 @@ const TIMELINE_MILESTONES = [
   try {
     supabase = await getSupabaseClient();
     if (!supabase) throw new Error('Supabase client unavailable');
+
+    supabase.auth.getSession().then(({ data }) => {
+      const session = data?.session;
+
+      if (!session && !hasAnonCode()) {
+        console.warn('[Anon Debug] No session or anonCode found, redirecting to /login');
+        window.location.href = '/login';
+      }
+    }).catch((err) => {
+      console.warn('Initial session check failed', err);
+    });
 
     // Cas robuste : si Google renvoie ?code dans l’URL, on échange immédiatement contre une session
     try {


### PR DESCRIPTION
## Summary
- add a helper to detect stored anonymous codes from localStorage
- redirect visitors to /login on startup if no Supabase session and no anon code are present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd0e31093c8321be27cd279843c01b