### PR TITLE
Remove temporary Anon Debug console logs

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1149,7 +1149,6 @@ const TIMELINE_MILESTONES = [
     if (code) {
       normalizedBody.code = code;
     }
-    console.log('[Anon Debug] Sending anon code', code || '(none)', 'to', slug);
     return callEdgeFunction(slug, { ...rest, body: normalizedBody });
   }
 
@@ -1336,7 +1335,6 @@ const TIMELINE_MILESTONES = [
       const session = data?.session;
 
       if (!session && !hasAnonCode()) {
-        console.warn('[Anon Debug] No session or anonCode found, redirecting to /login');
         window.location.href = '/login';
       }
     }).catch((err) => {

--- a/assets/messages.js
+++ b/assets/messages.js
@@ -545,7 +545,6 @@ async function anonMessagesRequest(code_unique, { since = null } = {}) {
     const payload = { action: 'recent-activity', code };
     if (since) payload.since = since;
     const url = '/api/edge/anon-messages';
-    console.log('[Anon Debug] Sending anon code', code || '(none)', 'to', 'anon-messages');
     console.debug("Calling Supabase function:", url, payload);
     const res = await fetch(url, {
       method: 'POST',
@@ -636,7 +635,6 @@ async function anonMessagesActionRequest(action, payload = {}) {
   if (!code) throw new Error('Code unique manquant');
   const url = '/api/edge/anon-messages';
   const payloadToSend = { action, code, ...payload };
-  console.log('[Anon Debug] Sending anon code', code || '(none)', 'to', 'anon-messages');
   console.debug("Calling Supabase function:", url, payloadToSend);
   const res = await fetch(url, {
     method: 'POST',
@@ -663,7 +661,6 @@ async function anonCommunityRequest(action, payload = {}) {
   if (!code) throw new Error('Code unique manquant');
   const url = '/api/edge/anon-community';
   const payloadToSend = { action, code, ...payload };
-  console.log('[Anon Debug] Sending anon code', code || '(none)', 'to', 'anon-community');
   console.debug("Calling Supabase function:", url, payloadToSend);
   const response = await fetch(url, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- remove temporary [Anon Debug] console logging from anon request helpers
- keep anon code injection logic intact while cleaning up redundant console noise

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd0fba0534832190d995fc6787ecad