### PR TITLE
Fix login routing to keep home public

### DIFF
--- a/assets/messages.js
+++ b/assets/messages.js
@@ -183,6 +183,14 @@ async function fetchAnonProfileByCode(rawCode) {
 }
 
 function presentLoginGate(){
+  try {
+    const target = '/#/login';
+    const alreadyOnLogin = window.location.pathname === '/' && window.location.hash === target;
+    if (!alreadyOnLogin) {
+      window.location.href = target;
+      return;
+    }
+  } catch {}
   const shell = $('#messages-shell');
   if (shell) shell.hidden = true;
   const gate = $('#login-gate');


### PR DESCRIPTION
## Summary
- ensure the SPA only redirects to the login view when navigating to protected routes while keeping the header and footer visible
- update the standalone messages page to send unauthenticated visitors to the central login route

## Testing
- node --check assets/app.js
- node --check assets/messages.js

------
https://chatgpt.com/codex/tasks/task_e_68dd27edde24832195b161ca217d0f24