### PR TITLE
Fix login gate redirection on messages page

### DIFF
--- a/assets/messages.js
+++ b/assets/messages.js
@@ -241,16 +241,15 @@ async function fetchAnonProfileByCode(rawCode) {
 }
 
 function presentLoginGate(){
-  try {
-    if (redirectToLoginPage({ replace: true })) return;
-  } catch {}
+  const gate = $('#login-gate');
+  if (!gate) {
+    try { redirectToLoginPage({ replace: true }); } catch {}
+    return;
+  }
   const shell = $('#messages-shell');
   if (shell) shell.hidden = true;
-  const gate = $('#login-gate');
-  if (gate) {
-    gate.hidden = false;
-    gate.classList.add('active');
-  }
+  gate.hidden = false;
+  gate.classList.add('active');
   stopAnonNotifPolling();
   if (messagesChannel) {
     try { supabase?.removeChannel(messagesChannel); } catch (e) {}


### PR DESCRIPTION
## Summary
- stop the messages login gate from automatically redirecting to the dashboard
- only fall back to the SPA login page if the embedded gate is not available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3264702483219fba9e0275ae82f5