### PR TITLE
Fix: point front to Supabase Functions + context correctness

### DIFF
--- a/assets/supabase-edge-client.js
+++ b/assets/supabase-edge-client.js
@@ -1,0 +1,101 @@
+import { loadSupabaseEnv } from './supabase-env-loader.js';
+
+const DEFAULT_EDGE_FUNCTION_BASE = '/api/edge';
+let lastEnv = null;
+
+function rememberEnv(env) {
+  if (env && typeof env === 'object') {
+    lastEnv = env;
+  }
+  return lastEnv || {};
+}
+
+export function resolveEdgeFunctionBase(explicitEnv) {
+  const env = explicitEnv || (typeof window !== 'undefined' ? window.__SUPABASE_ENV__ : null) || lastEnv || {};
+  const rawBase = typeof env.functionsUrl === 'string' ? env.functionsUrl.trim() : '';
+  if (rawBase) {
+    return rawBase.replace(/\/+$/, '');
+  }
+  return DEFAULT_EDGE_FUNCTION_BASE;
+}
+
+async function ensureEnv() {
+  if (typeof window !== 'undefined' && window.__SUPABASE_ENV__) {
+    return rememberEnv(window.__SUPABASE_ENV__);
+  }
+  const env = await loadSupabaseEnv();
+  return rememberEnv(env);
+}
+
+export async function callEdgeFunction(name, { method = 'POST', body, headers = {}, getAuthToken, signal } = {}) {
+  const env = await ensureEnv();
+  const baseUrl = resolveEdgeFunctionBase(env);
+  const finalHeaders = {
+    'Content-Type': 'application/json',
+    ...headers,
+  };
+  if (env?.anonKey) {
+    finalHeaders.apikey = env.anonKey;
+  }
+  if (body === undefined) {
+    delete finalHeaders['Content-Type'];
+  }
+  let authValue = env?.anonKey || '';
+  if (typeof getAuthToken === 'function') {
+    try {
+      const token = await getAuthToken();
+      if (token) {
+        authValue = token;
+      }
+    } catch (err) {
+      console.warn('callEdgeFunction: getAuthToken failed', err);
+    }
+  }
+  if (authValue) {
+    finalHeaders.Authorization = `Bearer ${authValue}`;
+  }
+  const requestInit = {
+    method,
+    headers: finalHeaders,
+    signal,
+  };
+  if (body !== undefined) {
+    requestInit.body = JSON.stringify(body);
+  }
+  const url = `${baseUrl}/${name}`;
+  let response;
+  try {
+    response = await fetch(url, requestInit);
+  } catch (err) {
+    const networkError = new Error('Connexion au service Supabase impossible.');
+    networkError.cause = err;
+    throw networkError;
+  }
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.toLowerCase().includes('application/json')) {
+    const rawBody = await response.text().catch(() => '');
+    const err = new Error('Mauvaise URL de fonctions (HTML reçu)');
+    err.status = response.status;
+    err.statusText = response.statusText;
+    err.body = rawBody;
+    throw err;
+  }
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message = (typeof payload?.error === 'string' && payload.error.trim())
+      || (typeof payload?.message === 'string' && payload.message.trim())
+      || '';
+    const err = new Error(message || 'Service indisponible');
+    err.status = response.status;
+    err.statusText = response.statusText;
+    err.details = payload?.details ?? null;
+    throw err;
+  }
+  if (payload?.success === false) {
+    const err = new Error(payload?.error || 'Service indisponible');
+    err.details = payload?.details ?? null;
+    err.status = response.status;
+    throw err;
+  }
+  return payload?.data ?? payload ?? null;
+}

--- a/assets/supabase-env-loader.js
+++ b/assets/supabase-env-loader.js
@@ -2,9 +2,14 @@ let cache = null;
 let loadingPromise = null;
 
 function normalize(raw = {}) {
-  const url = raw.url || raw.SUPABASE_URL || '';
+  const restUrl = raw.restUrl || raw.url || raw.SUPABASE_REST_URL || raw.SUPABASE_URL || '';
+  const functionsUrl = raw.functionsUrl || raw.SUPABASE_FUNCTIONS_URL || '';
   const anonKey = raw.anonKey || raw.SUPABASE_ANON_KEY || '';
-  return { url, anonKey };
+  return {
+    restUrl,
+    functionsUrl,
+    anonKey,
+  };
 }
 
 function remember(env) {
@@ -15,8 +20,8 @@ function remember(env) {
   return cache;
 }
 
-export function setSupabaseEnv(url, anonKey) {
-  return remember({ url, anonKey });
+export function setSupabaseEnv(restUrl, anonKey, functionsUrl = '') {
+  return remember({ restUrl, anonKey, functionsUrl });
 }
 
 async function fetchEnvCandidate(src) {
@@ -32,20 +37,20 @@ async function fetchEnvCandidate(src) {
 }
 
 export async function loadSupabaseEnv() {
-  if (cache && cache.url && cache.anonKey) return cache;
+  if (cache && cache.restUrl && cache.anonKey) return cache;
   if (typeof window !== 'undefined' && window.__SUPABASE_ENV__) {
     return remember(window.__SUPABASE_ENV__);
   }
   if (!loadingPromise) {
     loadingPromise = (async () => {
       let loaded = false;
-      const sources = ['/assets/supabase-env.json'];
+      const sources = [`/assets/supabase-env.json?ts=${Date.now()}`];
       for (const src of sources) {
         const candidate = await fetchEnvCandidate(src);
         if (!candidate) continue;
         remember(candidate);
         loaded = true;
-        if (candidate.url && candidate.anonKey) break;
+        if (candidate.restUrl && candidate.anonKey) break;
       }
       if (!loaded) {
         console.warn('supabase-env.json manquant, vérifiez vos assets');

--- a/assets/supabase-env.example.json
+++ b/assets/supabase-env.example.json
@@ -1,0 +1,5 @@
+{
+  "restUrl": "https://<SUPABASE_PROJECT_ID>.supabase.co/rest/v1",
+  "functionsUrl": "https://<SUPABASE_PROJECT_ID>.supabase.co/functions/v1",
+  "anonKey": "<SUPABASE_ANON_KEY>"
+}

--- a/assets/supabase-env.json
+++ b/assets/supabase-env.json
@@ -1,4 +1,5 @@
 {
-  "url": "https://myrwcjurblksypvekuzb.supabase.co",
+  "restUrl": "https://myrwcjurblksypvekuzb.supabase.co/rest/v1",
+  "functionsUrl": "https://myrwcjurblksypvekuzb.supabase.co/functions/v1",
   "anonKey": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im15cndjanVyYmxrc3lwdmVrdXpiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTczNjE4NjksImV4cCI6MjA3MjkzNzg2OX0.WOXYXA1GEFkqkLj_Str4yK4by7kmpwg9-KCBGPkDDQI"
 }

--- a/tools/smoke-tests.mjs
+++ b/tools/smoke-tests.mjs
@@ -1,0 +1,29 @@
+import fetch from 'node-fetch';
+
+const env = {
+  functionsUrl: 'https://myrwcjurblksypvekuzb.supabase.co/functions/v1',
+  anonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im15cndjanVyYmxrc3lwdmVrdXpiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTczNjE4NjksImV4cCI6MjA3MjkzNzg2OX0.WOXYXA1GEFkqkLj_Str4yK4by7kmpwg9-KCBGPkDDQI',
+};
+
+async function hit(fn, body) {
+  const url = `${env.functionsUrl}/${fn}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type':'application/json',
+      'apikey': env.anonKey,
+      'Authorization': `Bearer ${env.anonKey}`
+    },
+    body: JSON.stringify(body||{})
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`${fn} ${res.status}: ${text}`);
+  console.log(fn, 'OK:', text.slice(0, 200));
+}
+
+(async () => {
+  await hit('profiles-create-anon', {});
+  await hit('anon-children', { action:'list' });
+  // NOTE: likes-add nécessite un reply_id existant → juste vérifier 4xx/200 cohérent
+  // await hit('likes-add', { replyId:'<un_id_valide>' });
+})().catch(e => { console.error(e); process.exit(1); });

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "version": 2,
+  "rewrites": [
+    { "source": "/api/edge/(.*)", "destination": "https://myrwcjurblksypvekuzb.supabase.co/functions/v1/$1" }
+  ],
   "routes": [
     { "src": "/api/edge/(.*)", "dest": "/api/edge/[...slug].js" }
   ]


### PR DESCRIPTION
## Summary
- add Supabase REST/functions endpoints to the front-end config loader and client
- route edge-function calls through a shared helper with better auth/error handling and update messaging flows
- add a Vercel rewrite, local smoke-test script, and tighten Supabase function context/idempotency for likes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e19c980a0483219a8d2c2db6596991